### PR TITLE
Implement comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ It's on rubygems. Just `gem install ejson` or add it to your `Gemfile`.
 Keys in this file will remain in cleartext, while values will all be encrypted.
 It can be arbitrarily nested.
 
+Any values having keys beginning with underscores will be left unencrypted. e.g.:
+
+```json
+{
+  "some_secret": "ENC[MII.....]",
+  "_a_comment": "you can change this at http://foo.bar"
+}
+```
+
 #### 2) Encrypt the file:
 
     ejson

--- a/lib/ejson.rb
+++ b/lib/ejson.rb
@@ -27,30 +27,46 @@ class EJSON
       JSON.pretty_generate(encrypt_all(@data))
     end
 
-    def encrypt_all(data=@data)
+    def encrypt_all(name=nil, data=@data)
       case data
       when Hash
-        Hash[ data.map { |k,v| [k, encrypt_all(v)] } ]
+        Hash[ data.map { |k,v| [k, encrypt_all(k, v)] } ]
       when Array
-        data.map { |d| encrypt_all(d) }
+        data.map { |d| encrypt_all(name, d) }
       when String
-        encryption.dump(data)
+        encrypt_string(name, data)
       else
         data
       end
     end
 
-    def decrypt_all(data=@data)
+    def decrypt_all(name=nil, data=@data)
       case data
       when Hash
-        Hash[ data.map { |k,v| [k, decrypt_all(v)] } ]
+        Hash[ data.map { |k,v| [k, decrypt_all(k, v)] } ]
       when Array
-        data.map { |d| decrypt_all(d) }
+        data.map { |d| decrypt_all(nil, d) }
       when String
-        encryption.load(data)
+        decrypt_string(name, data)
       else
         data
       end
+    end
+
+    private
+
+    def encrypt_string(name, data)
+      return data if is_comment?(name)
+      encryption.dump(data)
+    end
+
+    def decrypt_string(name, data)
+      return data if is_comment?(name)
+      encryption.load(data)
+    end
+
+    def is_comment?(name)
+      name === String && name =~ /^_/
     end
 
   end

--- a/lib/ejson/version.rb
+++ b/lib/ejson/version.rb
@@ -1,3 +1,3 @@
 class Ejson
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/test/ejson_test.rb
+++ b/test/ejson_test.rb
@@ -8,13 +8,14 @@ class CLITest < Minitest::Unit::TestCase
   def test_ejson
     f = Tempfile.create("encrypt")
 
-    f.puts JSON.dump({a: "b"})
+    f.puts JSON.dump({a: "b", _comment: "d"})
     f.close
 
     encrypt f.path
 
     first_run = JSON.load(File.read(f.path))
     assert_match(/\AENC\[MIIB.*\]\z/, first_run["a"])
+    assert_equal "d", first_run["_comment"]
 
     File.open(f.path, "w") { |f2|
       f2.puts JSON.dump(first_run.merge({new_key: "new_value"}))
@@ -28,7 +29,7 @@ class CLITest < Minitest::Unit::TestCase
     assert_match(/\AENC\[MIIB.*\]\z/, second_run["new_key"])
 
     val = JSON.parse(decrypt(f.path))
-    assert_equal({"a" => "b", "new_key" => "new_value"}, val)
+    assert_equal({"a" => "b", "new_key" => "new_value", "_comment" => "d"}, val)
   ensure
     File.unlink(f.path)
   end


### PR DESCRIPTION
This adds comments (demarcated by prefixing an underscore) to EJSON. We could go fancier than this but I'd rather not build any sort of schema- or grammar-awareness into EJSON. I want this library as dumb as possible.

/cc @jduff @wvanbergen @Shopify/stack
