### PR TITLE
ensure tests are backwards compatible to ruby 2.0

### DIFF
--- a/ejson.gemspec
+++ b/ejson.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor", "~> 0.18"
+  spec.add_development_dependency "rake", "~> 10.3.2"
 end

--- a/test/ejson_test.rb
+++ b/test/ejson_test.rb
@@ -6,7 +6,7 @@ require 'ejson/cli'
 class CLITest < Minitest::Unit::TestCase
 
   def test_ejson
-    f = Tempfile.create("encrypt")
+    f = Tempfile.new("encrypt")
 
     f.puts JSON.dump({a: "b"})
     f.close
@@ -34,7 +34,7 @@ class CLITest < Minitest::Unit::TestCase
   end
 
   def test_default_key_exists
-    f = Tempfile.create("encrypt")
+    f = Tempfile.new("encrypt")
 
     f.puts JSON.dump({a: "b"})
     f.close
@@ -50,7 +50,7 @@ class CLITest < Minitest::Unit::TestCase
   end
 
   def test_library_is_picky
-    f = Tempfile.create("decrypt")
+    f = Tempfile.new("decrypt")
     f.puts JSON.dump({a: "b"})
     f.close
     assert_raises(EJSON::Encryption::ExpectedEncryptedString) {


### PR DESCRIPTION
@eapache noticed that `Tempfile#create` is a Ruby 2.1 API call, but does not work in 2.0. This ensures backwards compatibility.

Also, I added rake to the development dependancies.
