### PR TITLE
accept string as key

### DIFF
--- a/lib/ejson.rb
+++ b/lib/ejson.rb
@@ -6,8 +6,8 @@ class EJSON
   extend Forwardable
   def_delegators :@encryption, :load_string, :dump_string
 
-  def initialize(public_key_file, private_key_file = nil)
-    @encryption = Encryption.new(public_key_file, private_key_file)
+  def initialize(public_key, private_key = nil)
+    @encryption = Encryption.new(public_key, private_key)
   end
 
   def load(json_text)

--- a/lib/ejson/encryption.rb
+++ b/lib/ejson/encryption.rb
@@ -7,10 +7,10 @@ class EJSON
     PrivateKeyMissing = Class.new(StandardError)
     ExpectedEncryptedString = Class.new(StandardError)
 
-    def initialize(public_key_file, private_key_file)
-      @public_key_x509 = load_public_key(public_key_file)
-      if private_key_file
-        @private_key_rsa = load_private_key(private_key_file)
+    def initialize(public_key, private_key)
+      @public_key_x509 = load_public_key(public_key)
+      if private_key
+        @private_key_rsa = load_private_key(private_key)
       end
     end
 
@@ -47,15 +47,16 @@ class EJSON
       pkcs7.decrypt(@private_key_rsa, @public_key_x509)
     end
 
-    def load_public_key(public_key_file)
-      public_key_pem = File.read(public_key_file)
-      OpenSSL::X509::Certificate.new(public_key_pem)
+    def load_public_key(public_key)
+      OpenSSL::X509::Certificate.new(get_pem(public_key))
     end
 
-    def load_private_key(private_key_file)
-      private_key_pem = File.read(private_key_file)
-      OpenSSL::PKey::RSA.new(private_key_pem)
+    def load_private_key(private_key)
+      OpenSSL::PKey::RSA.new(get_pem(private_key))
     end
 
+    def get_pem(string)
+      string =~ /^-----BEGIN/ ? string : File.read(string)
+    end
   end
 end

--- a/test/ejson_test.rb
+++ b/test/ejson_test.rb
@@ -60,6 +60,16 @@ class CLITest < Minitest::Unit::TestCase
     File.unlink(f.path)
   end
 
+  def test_key_strings
+    public_key = File.read(pubkey)
+    private_key = File.read(privkey)
+
+    @enc = EJSON::Encryption.new(public_key, private_key)
+
+    assert_equal public_key, @enc.instance_variable_get(:@public_key_x509).to_s
+    assert_equal private_key, @enc.instance_variable_get(:@private_key_rsa).to_s
+  end
+
   private
 
   def encrypt(path)


### PR DESCRIPTION
For review @burke

This makes it so EJSON can accept the keys in as strings in `pem` format.
