### PR TITLE
Give a proxy object that can be used as a generic serializer

### DIFF
--- a/lib/ejson.rb
+++ b/lib/ejson.rb
@@ -14,6 +14,27 @@ class EJSON
     Data.new(JSON.load(json_text), @encryption)
   end
 
+  def serializer
+    @serializer ||= Serializer.new(@encryption)
+  end
+
+  class Serializer
+
+    def initialize(encryption)
+      @encryption = encryption
+    end
+
+    def dump(data)
+      data = Data.new(data, @encryption) unless data.is_a?(Data)
+      data.dump
+    end
+
+    def load(data)
+      Data.new(JSON.parse(data), @encryption).decrypt_all
+    end
+
+  end
+
   class Data
     extend Forwardable
     def_delegators :@data, :[]=

--- a/test/ejson_test.rb
+++ b/test/ejson_test.rb
@@ -87,6 +87,18 @@ class CLITest < Minitest::Unit::TestCase
     assert_equal private_key, @enc.instance_variable_get(:@private_key_rsa).to_s
   end
 
+  def test_serializer_api
+    serializer = EJSON.new(pubkey, privkey).serializer
+    data = {'foo' => 'bar'}
+
+    assert_equal data, serializer.load(serializer.dump(data))
+  end
+
+  def test_serializer_safety
+    serializer = EJSON.new(pubkey, privkey).serializer
+    refute serializer.dump('foo' => 'bar').include?('bar')
+  end
+
   private
 
   def encrypt(path)


### PR DESCRIPTION
I want to use EJSON as a serializer in an ActiveRecord model.

Unfortunately EJSON do not respect the ruby Serializer convention, so I needed to add a proxy object to not break the API :/.

Example usage

``` ruby
class User
  serialize credentials, EJSON.new(pubkey, privkey).serializer
end
```

/review @burke @manygrams 
