### PR TITLE
Stop advising the creation of certificates with a blank subject.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ but passing the `-i` flag causes them to be overwritten to the input file.
 We use a single keypair internally; the default public key is fetched from S3
 on each run. However, you can generate your own keypair like so:
 
-    openssl req -x509 -nodes -days 100000 -newkey rsa:2048 -keyout privatekey.pem -out publickey.pem -subj '/'
+    openssl req -x509 -nodes -days 100000 -newkey rsa:2048 -keyout privatekey.pem -out publickey.pem -subj '/O=Your Organization'
 
 `publickey.pem` and `privatekey.pem` are created. Move `privatekey.pem`
 somewhere more private, and move `publickey.pem` somewhere more public.


### PR DESCRIPTION
## Problem

I tried to use ejson with jruby, and got the following error with the default certificate

```
OpenSSL::X509::CertificateError: Empty issuer DN not allowed in X509Certificates
       initialize at org/jruby/ext/openssl/X509Cert.java:161
  load_public_key at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/bundler/gems/ejson-84d9a21629fe/lib/ejson/encryption.rb:51
       initialize at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/bundler/gems/ejson-84d9a21629fe/lib/ejson/encryption.rb:11
       initialize at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/bundler/gems/ejson-84d9a21629fe/lib/ejson.rb:10
          decrypt at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/bundler/gems/ejson-84d9a21629fe/lib/ejson/cli.rb:18
              run at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/gems/thor-0.18.1/lib/thor/command.rb:27
   invoke_command at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/gems/thor-0.18.1/lib/thor/invocation.rb:120
         dispatch at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/gems/thor-0.18.1/lib/thor.rb:363
            start at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/gems/thor-0.18.1/lib/thor/base.rb:439
           (root) at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/bundler/gems/ejson-84d9a21629fe/bin/ejson:4
             load at org/jruby/RubyKernel.java:1101
           (root) at /Users/dylansmith/.rbenv/versions/jruby-1.7.6/lib/ruby/gems/shared/bin/ejson:23
```

If you look at the contents of the certificate with

``` shell
openssl x509 -text -in <(curl https://s3.amazonaws.com/shopify-ops/ejson-publickey.pem)
```

you can see that the issuer is in fact blank.  That is because this is a self-signed certificate, where the issuer is copied from the subject and a blank subject was provided when creating the certificate.
## Solution

The error happens on OpenSSL::X509::Certificate.new, so I don't know how to workaround that error in the code.  However, we can workaround the error when creating the self-signed certificate by specifying a non-blank subject (e.g. adding an organization name).  I provided a placeholder organization name in the command to generate a self-signed certificate that is in the README of this repo.
