### PR TITLE
Download public key rather than grabbing it each time.

### DIFF
--- a/lib/ejson/cli.rb
+++ b/lib/ejson/cli.rb
@@ -10,6 +10,7 @@ class EJSON
     DEFAULT_PUBLIC_KEY = "https://s3.amazonaws.com/shopify-ops/ejson-publickey.pem"
     class_option "privkey", type: :string, aliases: "-k", desc: "Path to PKCS7 private key in PEM format", default: ENV['EJSON_PRIVATE_KEY_PATH']
     class_option "pubkey",  type: :string, aliases: "-p", desc: "Path or URL to PKCS7 public key in PEM format",  default: ENV['EJSON_PUBLIC_KEY_PATH']
+    class_option "no-prompt", :type => :boolean, desc: "Don't prompt when downloading the default public key"
 
     default_task :encrypt
 
@@ -90,12 +91,14 @@ class EJSON
     end
 
     def download_public_key(url)
-      puts "EJSON is going to download the public key from: #{url}"
-      print "Do you want to continue? (Y/n):"
-      response = gets.chomp
-      unless response == "" || response.downcase == "y"
-        puts "Operation cancelled"
-        exit 0
+      unless options['no-prompt']
+        puts "EJSON is going to download the public key from: #{url}"
+        print "Do you want to continue? (Y/n):"
+        response = gets.chomp
+        unless response == "" || response.downcase == "y"
+          puts "Operation cancelled"
+          exit 0
+        end
       end
 
       uri = URI.parse(url)

--- a/test/ejson_test.rb
+++ b/test/ejson_test.rb
@@ -56,7 +56,7 @@ class CLITest < Minitest::Unit::TestCase
     f.puts JSON.dump({a: "b"})
     f.close
 
-    runcli "encrypt", f.path # no pubkey specified
+    runcli "encrypt", "--no-prompt", f.path # no pubkey specified
 
     first_run = JSON.load(File.read(f.path))
     # We don't have the decryption key to this, and it may change over time,


### PR DESCRIPTION
Searches `~/.ejson` and `/etc/ejson` for both the public and private key, and will prompt to download the default public key if none exists.
The search path can still be overridden with the command line and ENV vars.

@burke 
