### PR TITLE
Parallelize encryption to improve performance

### DIFF
--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/codegangsta/cli"
@@ -16,6 +17,8 @@ func execManpage(sec, page string) {
 }
 
 func main() {
+	// Encryption is expensive. We'd rather burn cycles on many cores than wait.
+	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Rather than using the built-in help printer, display the bundled manpages.
 	cli.HelpPrinter = func(templ string, data interface{}) {

--- a/json/pipeline.go
+++ b/json/pipeline.go
@@ -1,0 +1,73 @@
+package json
+
+type pipeline struct {
+	final        []byte
+	err          error
+	pendingBytes []byte
+	queue        chan queueItem
+	done         chan struct{}
+}
+
+type queueItem struct {
+	pr   <-chan promiseResult
+	bs   []byte
+	term bool
+}
+
+type promiseResult struct {
+	bytes []byte
+	err   error
+}
+
+func newPipeline() *pipeline {
+	pl := &pipeline{
+		queue: make(chan queueItem, 512),
+		done:  make(chan struct{}),
+	}
+	go pl.run()
+	return pl
+}
+
+func (p *pipeline) run() {
+	for qi := range p.queue {
+		if qi.term {
+			close(p.done)
+		} else if qi.pr != nil {
+			res := <-qi.pr
+			if res.err != nil {
+				p.err = res.err
+			}
+			p.final = append(p.final, res.bytes...)
+		} else {
+			p.final = append(p.final, qi.bs...)
+		}
+	}
+}
+
+func (p *pipeline) appendBytes(bs []byte) {
+	p.pendingBytes = append(p.pendingBytes, bs...)
+}
+
+func (p *pipeline) appendByte(b byte) {
+	p.pendingBytes = append(p.pendingBytes, b)
+}
+
+func (p *pipeline) appendPromise(ch <-chan promiseResult) {
+	p.flushPendingBytes()
+	p.queue <- queueItem{pr: ch}
+}
+
+func (p *pipeline) flush() ([]byte, error) {
+	p.flushPendingBytes()
+	p.queue <- queueItem{term: true}
+	<-p.done
+	close(p.queue)
+	return p.final, p.err
+}
+
+func (p *pipeline) flushPendingBytes() {
+	if len(p.pendingBytes) > 0 {
+		p.queue <- queueItem{bs: p.pendingBytes}
+		p.pendingBytes = nil
+	}
+}


### PR DESCRIPTION
@Shopify/locutus 

Turns out encryption is pretty slow.

![yak](https://s-media-cache-ak0.pinimg.com/236x/21/89/57/218957c9f2d17cfbc8e029a5f1221e0d.jpg)

Time to decrypt test file fetched from  https://edg.epa.gov/data.json and encrypted with a random key:

On my macbook:

* Go 1.4, GOMAXPROCS=1, master branch: 7.8s
* Go 1.5, GOMAXPROCS=1, master branch: 5.8s
* Go 1.5, GOMAXPROCS=1, this branch: 6.9s
* Go 1.5, GOMAXPROCS=8, this branch: 1.9s

On production infrastructure (first is Go 1.4, 1 proc, master; second is Go 1.5, 32 procs, optimize branch):

```
burke@borg3.ash:~ $ ./test_deployed
7.371902681s
burke@borg3.ash:~ $ ./test_go_1.5_optimize_branch
794.795795ms
```