### PR TITLE
Updated DecryptFile to return a byte slice

### DIFF
--- a/cmd/ejson/actions.go
+++ b/cmd/ejson/actions.go
@@ -39,8 +39,9 @@ func decryptAction(args []string, keydir, outFile string) error {
 		}
 		defer func() { _ = target.Close() }()
 	}
-	fmt.Fprintln(target, decrypted)
-	return nil
+
+	_, err = target.Write(decrypted)
+	return err
 }
 
 func keygenAction(args []string, keydir string, wFlag bool) error {

--- a/ejson_test.go
+++ b/ejson_test.go
@@ -89,10 +89,6 @@ func TestDecryptFile(t *testing.T) {
 			})
 		})
 
-		Convey("called with an JSON file containing unencrypted-but-encryptable secrets", func() {
-			Convey("should fail with a scary message", nil)
-		})
-
 		Convey("called with an invalid JSON file", func() {
 			readFile = func(p string) ([]byte, error) {
 				return []byte(`{"a": "b"]`), nil
@@ -143,7 +139,7 @@ func TestDecryptFile(t *testing.T) {
 			readFile = ioutil.ReadFile
 			Convey("should fail and describe that the key could not be found", func() {
 				So(err, ShouldBeNil)
-				So(out, ShouldEqual, `{"_public_key": "8d8647e2eeb6d2e31228e6df7da3df921ec3b799c3f66a171cd37a1ed3004e7d", "a": "b"}`)
+				So(string(out), ShouldEqual, `{"_public_key": "8d8647e2eeb6d2e31228e6df7da3df921ec3b799c3f66a171cd37a1ed3004e7d", "a": "b"}`)
 			})
 		})
 


### PR DESCRIPTION
- Updated `DecryptFile` to return a `[]byte` instead of a `string`.
- Now checks an error that was unchecked before.
- Updated the comments for `DecryptFile` to reflect what it's currently doing.
- Removed a test that looked like it was doing nothing.

cc @burke 