### PR TITLE
Node.js based runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 /rubygem/man/
 /rubygem/LICENSE.txt
 /rubygem/lib/ejson/version.rb
+/npm/build/
+/npm/man/
+/npm/LICENSE.txt
 .bundle
 vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 /npm/build/
 /npm/man/
 /npm/LICENSE.txt
+/npm/VERSION
 .bundle
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ npm/VERSION: VERSION
 	cd npm && npm version `cat ./VERSION`
 
 clean:
-	rm -rf build pkg rubygem/{LICENSE.txt,lib/ejson/version.rb,build,*.gem}
+	rm -rf build pkg rubygem/{LICENSE.txt,lib/ejson/version.rb,build,*.gem} npm/{VERSION,LICENSE.txt,build,*.gem}
 
 dev_bootstrap:
 	go get ./...

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GODEP_PATH=$(shell pwd)/Godeps/_workspace
 
 BUNDLE_EXEC=bundle exec
 
-.PHONY: default all binaries gem man clean dev_bootstrap
+.PHONY: default all binaries gem man npm clean dev_bootstrap
 
 default: all
 all: gem deb
@@ -81,6 +81,32 @@ $(DEB): build/bin/linux-amd64 man
 		--url="https://github.com/Shopify/ejson" \
 		./build/man/=/usr/share/man/ \
 		./$<=/usr/bin/$(NAME)
+
+npm: \
+	npm/build/linux-amd64/ejson \
+	npm/build/darwin-amd64/ejson \
+	npm/man \
+	npm/LICENSE.txt \
+	npm/VERSION
+	echo 'ready for "npm publish"'
+
+npm/build/linux-amd64/ejson: build/bin/linux-amd64
+	mkdir -p $(@D)
+	cp -a "$<" "$@"
+
+npm/build/darwin-amd64/ejson: build/bin/darwin-amd64
+	mkdir -p $(@D)
+	cp -a "$<" "$@"
+
+npm/LICENSE.txt: LICENSE.txt
+	cp "$<" "$@"
+
+npm/man: man
+	cp -a build/man $@
+
+npm/VERSION: VERSION
+	cp VERSION $@
+	cd npm && npm version `cat ./VERSION`
 
 clean:
 	rm -rf build pkg rubygem/{LICENSE.txt,lib/ejson/version.rb,build,*.gem}

--- a/npm/bin/ejson
+++ b/npm/bin/ejson
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+var execSync = require('child_process').execSync;
+var path = require('path');
+
+var platform, dir, bindir;
+
+platform = execSync('uname -sm');
+
+if (/^Darwin/.test(platform)) {
+  dir = 'darwin-amd64';
+} else if (/^Linux.*64/.test(platform)) {
+  dir = 'linux-amd64';
+} else {
+  throw new Error('Ejson is not supported on your platform.');
+}
+
+bindir = path.resolve(__dirname, '../build/' + dir);
+mandir = path.resolve(__dirname, '../man');
+
+process.env.PATH = bindir + path.delimiter + process.env.PATH;
+process.env.MANPATH = mandir + path.delimiter + (process.env.MANPATH || '');
+
+execSync('ejson ' + process.argv.slice(2).join(' '), { stdio: [0, 1, 2] });

--- a/npm/package.json
+++ b/npm/package.json
@@ -9,7 +9,6 @@
     "ejson": "bin/ejson"
   },
   "scripts": {
-    "prepublish": "cp -a ../build . && cp -a ../man . && cp ../LICENSE.txt . && npm version `cat ../VERSION`",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "darep",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ejson",
+  "version": "1.0.1",
+  "description": "Secret management by encrypting values in a JSON hash with a public/private keypair",
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "bin": {
+    "ejson": "bin/ejson"
+  },
+  "scripts": {
+    "prepublish": "cp -a ../build . && cp -a ../man . && cp ../LICENSE.txt . && npm version `cat ../VERSION`",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "darep",
+  "license": "MIT"
+}


### PR DESCRIPTION
Hiya! I love ejson and use it a lot (thanks to @n1koo) – even in JS apps :) But it's a bit of a bother to set up in JS environment. So here's a Node.js based runner. Basically just translated the Ruby gem to JS.

Some notes:
- I did not try to publish this with `npm publish` yet (there's already ejson in npm: https://www.npmjs.com/package/ejson)
- Author in package.json is myself – change to Shopify or something?
- I named the directory `npm` but it could be `node` or `js` just as well
- You can test this locally with `npm install --save /path/to/ejson/npm` or `npm install -g /path/to/ejson/npm` after running `make npm` first

Let me know what you think 👀
