### PR TITLE
Preserve whitespace, including trailing newline.

### DIFF
--- a/json/walker_test.go
+++ b/json/walker_test.go
@@ -29,7 +29,8 @@ type testCase struct {
 var testCases = []testCase{
 	{`{"a": "b"}`, `{"a": "E"}`},                     // encryption
 	{`{"a" : "b"}`, `{"a" : "E"}`},                   // weird spacing
-	{` {  "a"  :"b" } `, ` {  "a"  :"E"}`},           // we could but don't preserve trailing spaces
+	{` {  "a"  :"b" } `, ` {  "a"  :"E" } `},         // trailing spaces
+	{`{"a": "b"}` + "\n", `{"a": "E"}` + "\n"},       // trailing newline
 	{`{"_a": "b"}`, `{"_a": "b"}`},                   // commenting
 	{`{"a": "b", "c": "d"}`, `{"a": "E", "c": "E"}`}, // order-dependence
 	{`{"a": 1}`, `{"a": 1}`},                         // numbers


### PR DESCRIPTION
For review @burke @Roxot

ejson makes some irritating changes to whitespace. This PR is an attempt to preserve all whitespace from the input file. It's the first Go I've written, so I doubt I've done this in the most elegant way.

Fixes https://github.com/Shopify/ejson/issues/16