### PR TITLE
Include newline in key file.

### DIFF
--- a/cmd/ejson/actions.go
+++ b/cmd/ejson/actions.go
@@ -52,7 +52,7 @@ func keygenAction(args []string, keydir string, wFlag bool) error {
 
 	if wFlag {
 		keyFile := fmt.Sprintf("%s/%s", keydir, pub)
-		err := writeFile(keyFile, []byte(priv), 0440)
+		err := writeFile(keyFile, append([]byte(priv), '\n'), 0440)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
For review @burke @Roxot

This adds a trailing newline to key files, as suggested in #16.

I verified that the decrypt operation is happy with the new format.

Fixes #16.