### PR TITLE
Allow private key to be passed in as a CLI option or an environment variable

### DIFF
--- a/cmd/ejson/actions.go
+++ b/cmd/ejson/actions.go
@@ -22,11 +22,11 @@ func encryptAction(args []string) error {
 	return nil
 }
 
-func decryptAction(args []string, keydir, outFile string) error {
+func decryptAction(args []string, keydir, privkeyFromEnv, outFile string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("exactly one file path must be given")
 	}
-	decrypted, err := ejson.DecryptFile(args[0], keydir)
+	decrypted, err := ejson.DecryptFile(args[0], keydir, privkeyFromEnv)
 	if err != nil {
 		return err
 	}

--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -39,6 +39,12 @@ func main() {
 			Usage:  "Directory containing EJSON keys",
 			EnvVar: "EJSON_KEYDIR",
 		},
+		cli.StringFlag{
+			Name:   "privatekey",
+			Value:  "",
+			Usage:  "The EJSON private key needed to decrypt the file",
+			EnvVar: "EJSON_PRIVATE_KEY",
+		},
 	}
 	app.Usage = "manage encrypted secrets using public key encryption"
 	app.Version = VERSION
@@ -67,7 +73,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) {
-				if err := decryptAction(c.Args(), c.GlobalString("keydir"), c.String("o")); err != nil {
+				if err := decryptAction(c.Args(), c.GlobalString("keydir"), c.GlobalString("privatekey"), c.String("o")); err != nil {
 					fmt.Println("Decryption failed:", err)
 					os.Exit(1)
 				}

--- a/ejson_test.go
+++ b/ejson_test.go
@@ -154,8 +154,8 @@ func TestDecryptFile(t *testing.T) {
 
 		Convey("called with a valid keypair and a corresponding entry in keydir", func() {
 			setData(tempFileName, []byte(`{"_public_key": "`+validPubKey+`", "a": "EJ[1:KR1IxNZnTZQMP3OR1NdOpDQ1IcLD83FSuE7iVNzINDk=:XnYW1HOxMthBFMnxWULHlnY4scj5mNmX:ls1+kvwwu2ETz5C6apgWE7Q=]"}`))
-			Convey("should fail and describe that the key could not be found", func() {
 			out, err := DecryptFile(tempFileName, tempDir, "")
+			Convey("should succeed and output the decrypted secrets", func() {
 				So(err, ShouldBeNil)
 				So(string(out), ShouldEqual, `{"_public_key": "`+validPubKey+`", "a": "b"}`)
 			})


### PR DESCRIPTION
After fetching the private key from S3 we need to write it to disk so that ejson can use it to decrypt. It would be better if we could avoid writing it to disk and pass the key directly into ejson via an environment variable or option. Use cases:

- Docker containers. The private key is fetched from secure storage on
container start then ejson is executed with the `privatekey` option to
obtain the decrypted secrets.
- Heroku. The private key is provided via `EJSON_PRIVATE_KEY` then ejson
is executed to obtain the decrypted secrets.

Addresses #23 