### PR TITLE
Flag to read private key from STDIN

### DIFF
--- a/cmd/ejson/actions.go
+++ b/cmd/ejson/actions.go
@@ -22,11 +22,11 @@ func encryptAction(args []string) error {
 	return nil
 }
 
-func decryptAction(args []string, keydir, outFile string) error {
+func decryptAction(args []string, keydir, userSuppliedPrivateKey, outFile string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("exactly one file path must be given")
 	}
-	decrypted, err := ejson.DecryptFile(args[0], keydir)
+	decrypted, err := ejson.DecryptFile(args[0], keydir, userSuppliedPrivateKey)
 	if err != nil {
 		return err
 	}

--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -39,6 +39,11 @@ func main() {
 			Usage:  "Directory containing EJSON keys",
 			EnvVar: "EJSON_KEYDIR",
 		},
+		cli.StringFlag{
+			Name:  "private-key",
+			Value: "",
+			Usage: "The EJSON private key needed to decrypt the file",
+		},
 	}
 	app.Usage = "manage encrypted secrets using public key encryption"
 	app.Version = VERSION
@@ -67,7 +72,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) {
-				if err := decryptAction(c.Args(), c.GlobalString("keydir"), c.String("o")); err != nil {
+				if err := decryptAction(c.Args(), c.GlobalString("keydir"), c.GlobalString("private-key"), c.String("o")); err != nil {
 					fmt.Println("Decryption failed:", err)
 					os.Exit(1)
 				}

--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"syscall"
+	"strings"
 
 	"github.com/codegangsta/cli"
 )
@@ -79,7 +80,7 @@ func main() {
 						fmt.Println("Failed to read from stdin:", err)
 						os.Exit(1)
 					}
-					userSuppliedPrivateKey = string(stdinContent)
+					userSuppliedPrivateKey = strings.TrimSpace(string(stdinContent))
 				}
 				if err := decryptAction(c.Args(), c.GlobalString("keydir"), userSuppliedPrivateKey, c.String("o")); err != nil {
 					fmt.Println("Decryption failed:", err)

--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"syscall"
@@ -39,11 +40,6 @@ func main() {
 			Usage:  "Directory containing EJSON keys",
 			EnvVar: "EJSON_KEYDIR",
 		},
-		cli.StringFlag{
-			Name:  "private-key",
-			Value: "",
-			Usage: "The EJSON private key needed to decrypt the file",
-		},
 	}
 	app.Usage = "manage encrypted secrets using public key encryption"
 	app.Version = VERSION
@@ -70,9 +66,22 @@ func main() {
 					Name:  "o",
 					Usage: "print output to the provided file, rather than stdout",
 				},
+				cli.BoolTFlag{
+					Name:  "key-from-stdin",
+					Usage: "Read the private key from STDIN",
+				},
 			},
 			Action: func(c *cli.Context) {
-				if err := decryptAction(c.Args(), c.GlobalString("keydir"), c.GlobalString("private-key"), c.String("o")); err != nil {
+				var userSuppliedPrivateKey string
+				if c.Bool("key-from-stdin") {
+					stdinContent, err := ioutil.ReadAll(os.Stdin)
+					if err != nil {
+						fmt.Println("Failed to read from stdin:", err)
+						os.Exit(1)
+					}
+					userSuppliedPrivateKey = string(stdinContent)
+				}
+				if err := decryptAction(c.Args(), c.GlobalString("keydir"), userSuppliedPrivateKey, c.String("o")); err != nil {
 					fmt.Println("Decryption failed:", err)
 					os.Exit(1)
 				}

--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -66,7 +66,7 @@ func main() {
 					Name:  "o",
 					Usage: "print output to the provided file, rather than stdout",
 				},
-				cli.BoolTFlag{
+				cli.BoolFlag{
 					Name:  "key-from-stdin",
 					Usage: "Read the private key from STDIN",
 				},

--- a/ejson.go
+++ b/ejson.go
@@ -100,7 +100,7 @@ func EncryptFileInPlace(filePath string) (int, error) {
 // Decrypt reads an ejson stream from 'in' and writes the decrypted data to 'out'.
 // The private key is expected to be under 'keydir'.
 // Returns error upon failure, or nil on success.
-func Decrypt(in io.Reader, out io.Writer, keydir string) error {
+func Decrypt(in io.Reader, out io.Writer, keydir string, userSuppliedPrivateKey string) error {
 	data, err := ioutil.ReadAll(in)
 	if err != nil {
 		return err
@@ -111,7 +111,7 @@ func Decrypt(in io.Reader, out io.Writer, keydir string) error {
 		return err
 	}
 
-	privkey, err := findPrivateKey(pubkey, keydir)
+	privkey, err := findPrivateKey(pubkey, keydir, userSuppliedPrivateKey)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func Decrypt(in io.Reader, out io.Writer, keydir string) error {
 // There must exist a file in keydir whose name is the public key from the
 // EJSON document, and whose contents are the corresponding private key. See
 // README.md for more details on this.
-func DecryptFile(filePath, keydir string) ([]byte, error) {
+func DecryptFile(filePath, keydir string, userSuppliedPrivateKey string) ([]byte, error) {
 	if _, err := os.Stat(filePath); err != nil {
 		return nil, err
 	}
@@ -155,12 +155,12 @@ func DecryptFile(filePath, keydir string) ([]byte, error) {
 
 	var outBuffer bytes.Buffer
 
-	err = Decrypt(file, &outBuffer, keydir)
+	err = Decrypt(file, &outBuffer, keydir, userSuppliedPrivateKey)
 
 	return outBuffer.Bytes(), err
 }
 
-func findPrivateKey(pubkey [32]byte, keydir string) (privkey [32]byte, err error) {
+func readPrivateKeyFromDisk(pubkey [32]byte, keydir string) (privkey string, err error) {
 	keyFile := fmt.Sprintf("%s/%x", keydir, pubkey)
 	var fileContents []byte
 	fileContents, err = ioutil.ReadFile(keyFile)
@@ -168,17 +168,30 @@ func findPrivateKey(pubkey [32]byte, keydir string) (privkey [32]byte, err error
 		err = fmt.Errorf("couldn't read key file (%s)", err.Error())
 		return
 	}
+	privkey = string(fileContents)
+	return
+}
 
-	bs, err := hex.DecodeString(strings.TrimSpace(string(fileContents)))
+func findPrivateKey(pubkey [32]byte, keydir string, userSuppliedPrivateKey string) (privkey [32]byte, err error) {
+	var privkeyString string
+	if userSuppliedPrivateKey != "" {
+		privkeyString = userSuppliedPrivateKey
+	} else {
+		privkeyString, err = readPrivateKeyFromDisk(pubkey, keydir)
+		if err != nil {
+			return privkey, err
+		}
+	}
+
+	privkeyBytes, err := hex.DecodeString(strings.TrimSpace(privkeyString))
 	if err != nil {
 		return
 	}
 
-	if len(bs) != 32 {
-		err = fmt.Errorf("invalid private key retrieved from keydir")
+	if len(privkeyBytes) != 32 {
+		err = fmt.Errorf("invalid private key")
 		return
 	}
-
-	copy(privkey[:], bs)
+	copy(privkey[:], privkeyBytes)
 	return
 }

--- a/ejson_test.go
+++ b/ejson_test.go
@@ -153,8 +153,8 @@ func TestDecryptFile(t *testing.T) {
 
 		Convey("called with a valid keypair and a corresponding entry in keydir", func() {
 			setData(tempFileName, []byte(`{"_public_key": "`+validPubKey+`", "a": "EJ[1:KR1IxNZnTZQMP3OR1NdOpDQ1IcLD83FSuE7iVNzINDk=:XnYW1HOxMthBFMnxWULHlnY4scj5mNmX:ls1+kvwwu2ETz5C6apgWE7Q=]"}`))
-			Convey("should fail and describe that the key could not be found", func() {
 			out, err := DecryptFile(tempFileName, tempDir, "")
+			Convey("should succeed and output the decrypted secrets", func() {
 				So(err, ShouldBeNil)
 				So(string(out), ShouldEqual, `{"_public_key": "`+validPubKey+`", "a": "b"}`)
 			})

--- a/man/man1/ejson-decrypt.1.ronn
+++ b/man/man1/ejson-decrypt.1.ronn
@@ -3,7 +3,7 @@ ejson-decrypt(1) -- Decrypt an ejson file
 
 ## SYNOPSIS
 
-`ejson decrypt` [-o `<output file>`] FILE
+`ejson decrypt` [--key-from-stdin] [-o `<output file>`] FILE
 
 ## DESCRIPTION
 
@@ -15,6 +15,8 @@ be present in the keydir. See ejson(1) for instructions on changing the keydir.
 
   * `--out` FILE, `-o` FILE:
     If given, write the decrypted file to FILE rather than stdout.
+  * `--key-from-stdin`:
+    Read the private key from stdin.
 
 
 ## SEE ALSO


### PR DESCRIPTION
Removes the need to write the private key to decrypt an EJSON file.

Background: https://github.com/Shopify/ejson/pull/41

```
❯ ejson --private-key [private_key] decrypt test.ejson
{
  "_public_key": "[public_key]",
  "test": "sssh!"
}
```