### PR TITLE
Print error messages to stderr

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,4 +51,4 @@ DEPENDENCIES
   ronn
 
 BUNDLED WITH
-   1.15.0
+   1.16.0

--- a/cmd/ejson/actions.go
+++ b/cmd/ejson/actions.go
@@ -17,7 +17,7 @@ func encryptAction(args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Wrote %d bytes to %s.\n", n, filePath)
+		fmt.Fprint(os.Stderr, "Wrote %d bytes to %s.\n", n, filePath)
 	}
 	return nil
 }
@@ -58,7 +58,7 @@ func keygenAction(args []string, keydir string, wFlag bool) error {
 		}
 		fmt.Println(pub)
 	} else {
-		fmt.Printf("Public Key:\n%s\nPrivate Key:\n%s\n", pub, priv)
+		fmt.Fprintf(os.Stderr, "Public Key:\n%s\nPrivate Key:\n%s\n", pub, priv)
 	}
 	return nil
 }

--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -5,15 +5,15 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
-	"syscall"
 	"strings"
+	"syscall"
 
 	"github.com/codegangsta/cli"
 )
 
 func execManpage(sec, page string) {
 	if err := syscall.Exec("/usr/bin/env", []string{"/usr/bin/env", "man", sec, page}, os.Environ()); err != nil {
-		fmt.Println("Exec error:", err)
+		fmt.Fprintln(os.Stderr, "Exec error:", err)
 	}
 	os.Exit(1)
 }
@@ -53,7 +53,7 @@ func main() {
 			Usage:     "(re-)encrypt one or more EJSON files",
 			Action: func(c *cli.Context) {
 				if err := encryptAction(c.Args()); err != nil {
-					fmt.Println("Encryption failed:", err)
+					fmt.Fprintln(os.Stderr, "Encryption failed:", err)
 					os.Exit(1)
 				}
 			},
@@ -77,13 +77,13 @@ func main() {
 				if c.Bool("key-from-stdin") {
 					stdinContent, err := ioutil.ReadAll(os.Stdin)
 					if err != nil {
-						fmt.Println("Failed to read from stdin:", err)
+						fmt.Fprintln(os.Stderr, "Failed to read from stdin:", err)
 						os.Exit(1)
 					}
 					userSuppliedPrivateKey = strings.TrimSpace(string(stdinContent))
 				}
 				if err := decryptAction(c.Args(), c.GlobalString("keydir"), userSuppliedPrivateKey, c.String("o")); err != nil {
-					fmt.Println("Decryption failed:", err)
+					fmt.Fprintln(os.Stderr, "Decryption failed:", err)
 					os.Exit(1)
 				}
 			},
@@ -100,14 +100,14 @@ func main() {
 			},
 			Action: func(c *cli.Context) {
 				if err := keygenAction(c.Args(), c.GlobalString("keydir"), c.Bool("write")); err != nil {
-					fmt.Println("Key generation failed:", err)
+					fmt.Fprintln(os.Stderr, "Key generation failed:", err)
 					os.Exit(1)
 				}
 			},
 		},
 	}
 	if err := app.Run(os.Args); err != nil {
-		fmt.Println("Unexpected failure:", err)
+		fmt.Fprintln(os.Stderr, "Unexpected failure:", err)
 		os.Exit(1)
 	}
 }

--- a/dev.yml
+++ b/dev.yml
@@ -13,4 +13,4 @@ up:
 
 commands:
   build: make
-  test: go test
+  test: go test $(glide nv)


### PR DESCRIPTION
It'd be nice if commands like `ejson d` only ever output a json blob, and put their error messages into stderr

Also upgraded bundler, and changed dev test to test everything, not just the root dir