### PR TITLE
adds ejson2env

### DIFF
--- a/cmd/ejson2env/ejson2env.1.ronn
+++ b/cmd/ejson2env/ejson2env.1.ronn
@@ -1,0 +1,98 @@
+ejson2env(1) -- extract environment variables from an ejson file
+===========================================================================
+
+## SYNOPSIS
+
+`ejson2env` [`--keydir` <path>] <filename>
+
+## DESCRIPTION
+
+`ejson2env` is a utility for extracting environment variables from ejson
+files.
+
+See ejson(5) for more information on the `ejson` file format, and read on for a
+workflow example.
+
+## OPTIONS
+
+  * `--keydir`=<path>:
+    Path to directory containing private keys. Defaults to `/opt/ejson/keys`.
+    Setting `EJSON_KEYDIR` will also set this value, with lower precedence.
+
+  * `--key-from-stdin`:
+    If set, assumes that the key that decrypts the passed ejson file was 
+    passed in on standard input.
+
+## WORKFLOW
+
+### 1: Add environment variables to an ejson file
+
+If you do not have an existing ejson file, ejson(1) describes how to create
+private and public keys and create the initial ejson file.
+
+To add the environment variables, add a new key called "environment" at the 
+top level of the ejson file. 
+
+For example, adding a `DB_PASSWORD` environment variable would require 
+creating an `environment` object, with a `DB_PASSWORD` key value pair:
+
+```
+{
+  "_public_key": "<key>",
+  "environment": {
+    "DB_PASSWORD": "1234password"
+  }
+}
+```
+
+### 4: Encrypt the file
+
+Running `ejson encrypt` will then encrypt the contents of the `environment`
+object, as it does for other variables. 
+
+For example, running `ejson encrypt` against our example would generate 
+something similar to:
+
+```
+{
+  "_public_key": "<key>",
+  "environment": {
+    "DB_PASSWORD": "EJ[1:OrYT5AaCMOtskq44s2rIzZnoeWW9y5ciYEiV8FWAORc=:vlYfnSz0wuGHKXZ1yFqVnFP5PYrTNyMs:UR5ZeX7BnDWeoAjiy1Rp/nTDWsmmYtJrWmI=]"
+  }
+}
+```
+
+### 5: Export the environment variables
+
+`ejson2env` <filename> will write the export commands to standard output. 
+
+The following output would be generated for our example:
+
+```
+export DB_PASSWORD=1234password
+``` 
+
+You can then export them to the shell environment by calling the command
+surrounded by backticks. 
+
+For example:
+
+```
+#!/bin/sh
+
+`ejson2env /config/secrets.production.ejson`
+
+echo $DB_PASSWORD
+```
+
+## BUGS
+
+Please file bugs at https://github.com/Shopify/ejson
+
+## COPYRIGHT
+
+ejson2env is copyright (C) 2018 Shopify under MIT license.
+
+## SEE ALSO
+
+ejson(5) ejson-encrypt(1) ejson-decrypt(1) ejson-keygen(1)

--- a/cmd/ejson2env/env.go
+++ b/cmd/ejson2env/env.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	errNoEnv     = "environment is not set in ejson"
+	errEnvNotMap = "environment is not a map[string]interface{}"
+)
+
+// ExtractEnv extracts the environment values from the map[string]interface{}
+// containing all secrets, and returns a map[string]string containing the
+// key value pairs. If there's an issue (the environment key doesn't exist, for
+// example), returns an error.
+func ExtractEnv(secrets map[string]interface{}) (map[string]string, error) {
+	if nil == secrets["environment"] {
+		err := fmt.Errorf(errNoEnv)
+		return map[string]string{}, err
+	}
+
+	rawEnv, isMap := secrets["environment"].(map[string]interface{})
+	if !isMap {
+		err := fmt.Errorf(errEnvNotMap)
+		return map[string]string{}, err
+	}
+
+	envSecrets := make(map[string]string, len(rawEnv))
+
+	for key, rawValue := range rawEnv {
+		value, isString := rawValue.(string)
+
+		// Only export values that convert to strings properly.
+		if isString {
+			envSecrets[key] = value
+		}
+	}
+
+	return envSecrets, nil
+}
+
+// ExportEnv writes the passed environment values to the passed
+// io.Writer.
+func ExportEnv(output io.Writer, values map[string]string) {
+	for key, value := range values {
+		fmt.Fprintf(output, "export %s=%s\n", key, value)
+	}
+}

--- a/cmd/ejson2env/env_test.go
+++ b/cmd/ejson2env/env_test.go
@@ -49,14 +49,14 @@ func TestInvalidEnvironments(t *testing.T) {
 	_, err := ExtractEnv(testBad)
 	if nil == err {
 		t.Errorf("no error when passed a non-map environment")
-	} else if errEnvNotMap != err.Error() {
+	} else if errEnvNotMap != err {
 		t.Errorf("wrong error when passed a non-map environment: %s", err)
 	}
 
 	_, err = ExtractEnv(testNoEnv)
 	if nil == err {
 		t.Errorf("no error when passed a non-existiant environment")
-	} else if errNoEnv != err.Error() {
+	} else if errNoEnv != err {
 		t.Errorf("wrong error when passed a non-existiant environment: %s", err)
 	}
 

--- a/cmd/ejson2env/env_test.go
+++ b/cmd/ejson2env/env_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+const TestKeyValue = "2ed65dd6a16eab833cc4d2a860baa60042da34a58ac43855e8554ca87a5e557d"
+
+func TestLoadSecrets(t *testing.T) {
+
+	rawValues, err := ReadSecrets("test.ejson", "./key", TestKeyValue)
+	if nil != err {
+		t.Fatal(err)
+	}
+
+	envValues, err := ExtractEnv(rawValues)
+	if nil != err {
+		t.Fatal(err)
+	}
+
+	if "test_value" != envValues["test_key"] {
+		t.Error("Failed to decrypt")
+	}
+
+	var buf bytes.Buffer
+
+	ExportEnv(&buf, envValues)
+
+	if "export test_key=test_value\n" != buf.String() {
+		t.Errorf("generated invalid export code: \n---\n%s\n---", buf.String())
+	}
+
+}
+
+func TestInvalidEnvironments(t *testing.T) {
+	testGood := map[string]interface{}{
+		"environment": map[string]interface{}{
+			"test_key": "test_value",
+		},
+	}
+
+	testBad := map[string]interface{}{
+		"environment": "bad",
+	}
+
+	var testNoEnv map[string]interface{}
+
+	_, err := ExtractEnv(testBad)
+	if nil == err {
+		t.Errorf("no error when passed a non-map environment")
+	} else if errEnvNotMap != err.Error() {
+		t.Errorf("wrong error when passed a non-map environment: %s", err)
+	}
+
+	_, err = ExtractEnv(testNoEnv)
+	if nil == err {
+		t.Errorf("no error when passed a non-existiant environment")
+	} else if errNoEnv != err.Error() {
+		t.Errorf("wrong error when passed a non-existiant environment: %s", err)
+	}
+
+	_, err = ExtractEnv(testGood)
+	if nil != err {
+		t.Errorf("error when passed correctly formatted environment: %s", err)
+	}
+
+}

--- a/cmd/ejson2env/key.go
+++ b/cmd/ejson2env/key.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+)
+
+// readKey reads the contents of the passed reader, and
+// strips any preceding or ending whitespace.
+func readKey(reader io.Reader) (string, error) {
+	b, err := ioutil.ReadAll(reader)
+	if nil != err {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(b)), nil
+}

--- a/cmd/ejson2env/key.go
+++ b/cmd/ejson2env/key.go
@@ -8,8 +8,8 @@ import (
 
 // readKey reads the contents of the passed reader, and
 // strips any preceding or ending whitespace.
-func readKey(reader io.Reader) (string, error) {
-	b, err := ioutil.ReadAll(reader)
+func readKey(r io.Reader) (string, error) {
+	b, err := ioutil.ReadAll(r)
 	if nil != err {
 		return "", err
 	}

--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+// showUsage prints the usage message and the defaults to standard error.
+func showUsage(output io.Writer) {
+	flag.CommandLine.SetOutput(output)
+	fmt.Fprintf(flag.CommandLine.Output(), "usage: %s [-keydir path] [-key-from-stdin] file.ejson\n\n", os.Args[0])
+	flag.CommandLine.PrintDefaults()
+}
+
+// failAndShowUsage prints the error message to stderr, followed
+// by the usage information, before exiting with an error code.
+func failAndShowUsage(err error) {
+	fmt.Fprintf(os.Stderr, "%s\n\n", err)
+	showUsage(os.Stderr)
+	os.Exit(1)
+}
+
+// fail prints the error message to stderr, then ends execution.
+func fail(err error) {
+	fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+	os.Exit(1)
+}
+
+func main() {
+	var filename string
+	var keydir string
+	var fromStdin bool
+	var showHelp bool
+
+	var err error
+
+	flag.BoolVar(&showHelp, "help", false, "Show this usage message")
+	flag.BoolVar(&fromStdin, "key-from-stdin", false, "Read the private key from STDIN")
+	flag.StringVar(&keydir, "keydir", "/opt/ejson/keys", "Directory containing EJSON keys")
+
+	flag.Parse()
+
+	if showHelp {
+		showUsage(os.Stdout)
+		os.Exit(0)
+	}
+
+	if 1 <= flag.NArg() {
+		filename = flag.Arg(0)
+	}
+
+	if "" == filename {
+		failAndShowUsage(fmt.Errorf("no secrets.ejson filename passed"))
+	}
+
+	var userSuppliedPrivateKey string
+	if fromStdin {
+		userSuppliedPrivateKey, err = readKey(os.Stdin)
+		if err != nil {
+			fail(fmt.Errorf("failed to read from stdin: %s", err))
+		}
+	}
+
+	secrets, err := ReadSecrets(filename, keydir, userSuppliedPrivateKey)
+	if nil != err {
+		fail(fmt.Errorf("could not load ejson file: %s", err))
+	}
+
+	envValues, err := ExtractEnv(secrets)
+	if nil != err {
+		fail(fmt.Errorf("could not load environment from file: %s", err))
+	}
+
+	ExportEnv(os.Stdout, envValues)
+}

--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -1,77 +1,84 @@
 package main
 
 import (
-	"flag"
 	"fmt"
-	"io"
 	"os"
+
+	"github.com/urfave/cli"
 )
-
-// showUsage prints the usage message and the defaults to standard error.
-func showUsage(output io.Writer) {
-	flag.CommandLine.SetOutput(output)
-	fmt.Fprintf(flag.CommandLine.Output(), "usage: %s [-keydir path] [-key-from-stdin] file.ejson\n\n", os.Args[0])
-	flag.CommandLine.PrintDefaults()
-}
-
-// failAndShowUsage prints the error message to stderr, followed
-// by the usage information, before exiting with an error code.
-func failAndShowUsage(err error) {
-	fmt.Fprintf(os.Stderr, "%s\n\n", err)
-	showUsage(os.Stderr)
-	os.Exit(1)
-}
 
 // fail prints the error message to stderr, then ends execution.
 func fail(err error) {
-	fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+	fmt.Fprintf(os.Stderr, "error: %s\n", err)
 	os.Exit(1)
 }
 
-func main() {
-	var filename string
-	var keydir string
-	var fromStdin bool
-	var showHelp bool
-
-	var err error
-
-	flag.BoolVar(&showHelp, "help", false, "Show this usage message")
-	flag.BoolVar(&fromStdin, "key-from-stdin", false, "Read the private key from STDIN")
-	flag.StringVar(&keydir, "keydir", "/opt/ejson/keys", "Directory containing EJSON keys")
-
-	flag.Parse()
-
-	if showHelp {
-		showUsage(os.Stdout)
-		os.Exit(0)
-	}
-
-	if 1 <= flag.NArg() {
-		filename = flag.Arg(0)
-	}
-
-	if "" == filename {
-		failAndShowUsage(fmt.Errorf("no secrets.ejson filename passed"))
-	}
-
-	var userSuppliedPrivateKey string
-	if fromStdin {
-		userSuppliedPrivateKey, err = readKey(os.Stdin)
-		if err != nil {
-			fail(fmt.Errorf("failed to read from stdin: %s", err))
-		}
-	}
-
-	secrets, err := ReadSecrets(filename, keydir, userSuppliedPrivateKey)
+// exportSecrets wraps the read, extract, and export steps. Returns
+// an error if any step fails.
+func exportSecrets(filename, keyDir, privateKey string) error {
+	secrets, err := ReadSecrets(filename, keyDir, privateKey)
 	if nil != err {
-		fail(fmt.Errorf("could not load ejson file: %s", err))
+		return (fmt.Errorf("could not load ejson file: %s", err))
 	}
 
 	envValues, err := ExtractEnv(secrets)
 	if nil != err {
-		fail(fmt.Errorf("could not load environment from file: %s", err))
+		return fmt.Errorf("could not load environment from file: %s", err)
 	}
 
 	ExportEnv(os.Stdout, envValues)
+	return nil
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Usage = "get environment variables from ejson files"
+	app.Version = VERSION
+	app.Author = "Catherine Jones"
+	app.Email = "catherine.jones@shopify.com"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "keydir, k",
+			Value:  "/opt/ejson/keys",
+			Usage:  "Directory containing EJSON keys",
+			EnvVar: "EJSON_KEYDIR",
+		},
+		cli.BoolFlag{
+			Name:  "key-from-stdin",
+			Usage: "Read the private key from STDIN",
+		},
+	}
+
+	app.Action = func(c *cli.Context) {
+		var filename string
+
+		keydir := c.String("keydir")
+
+		var userSuppliedPrivateKey string
+		if c.Bool("key-from-stdin") {
+			var err error
+			userSuppliedPrivateKey, err = readKey(os.Stdin)
+			if err != nil {
+				fail(fmt.Errorf("failed to read from stdin: %s", err))
+			}
+		}
+
+		if 1 <= len(c.Args()) {
+			filename = c.Args().Get(0)
+		}
+
+		if "" == filename {
+			fail(fmt.Errorf("no secrets.ejson filename passed"))
+		}
+
+		if err := exportSecrets(filename, keydir, userSuppliedPrivateKey); nil != err {
+			fail(err)
+		}
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "Unexpected failure:", err)
+		os.Exit(1)
+	}
+
 }

--- a/cmd/ejson2env/secrets.go
+++ b/cmd/ejson2env/secrets.go
@@ -10,7 +10,7 @@ import (
 // ReadSecrets reads the secrets for the passed filename and
 // returns them as a map[string]interface{}.
 func ReadSecrets(filename, keyDir, privateKey string) (map[string]interface{}, error) {
-	var secrets map[string]interface{}
+	secrets := make(map[string]interface{})
 
 	decrypted, err := ejson.DecryptFile(filename, keyDir, privateKey)
 	if nil != err {

--- a/cmd/ejson2env/secrets.go
+++ b/cmd/ejson2env/secrets.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/Shopify/ejson"
+)
+
+// ReadSecrets reads the secrets for the passed filename and
+// returns them as a map[string]interface{}.
+func ReadSecrets(filename, keyDir, privateKey string) (map[string]interface{}, error) {
+	var secrets map[string]interface{}
+
+	decrypted, err := ejson.DecryptFile(filename, keyDir, privateKey)
+	if nil != err {
+		return secrets, err
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(decrypted))
+
+	err = decoder.Decode(&secrets)
+	if nil != err {
+		return secrets, err
+	}
+
+	return secrets, nil
+}

--- a/cmd/ejson2env/test.ejson
+++ b/cmd/ejson2env/test.ejson
@@ -1,0 +1,6 @@
+{
+    "_public_key": "795e671066eef17025c816b6d7c4f5c658b191cfaa31baca69963d761606415c",
+    "environment": {
+        "test_key": "EJ[1:OrYT5AaCMOtskq44s2rIzZnoeWW9y5ciYEiV8FWAORc=:vlYfnSz0wuGHKXZ1yFqVnFP5PYrTNyMs:UR5ZeX7BnDWeoAjiy1Rp/nTDWsmmYtJrWmI=]"
+    }
+}

--- a/cmd/ejson2env/version.go
+++ b/cmd/ejson2env/version.go
@@ -1,0 +1,4 @@
+package main
+
+// VERSION contains the application version
+const VERSION string = "1.0.0"


### PR DESCRIPTION
This pull request adds the ejson2env command, which aids with the export of environment variables stored in ejson files.

For example, with an ejson file containing:

```
{
    "_public_key": "<key>",
    "environment": {
        "DB_PASSWORD": "EJ[1:OrYT5AaCMOtskq44s2rIzZnoeWW9y5ciYEiV8FWAORc=:vlYfnSz0wuGHKXZ1yFqVnFP5PYrTNyMs:UR5ZeX7BnDWeoAjiy1Rp/nTDWsmmYtJrWmI=]"                                                                                                                               
    }
}
```

Running `ejson2env` would output:

```
export DB_PASSWORD=test1234
```

This command would then be called in entrypoint shell scripts.