### PR TITLE
Move non-error output back to stdout

### DIFF
--- a/cmd/ejson/actions.go
+++ b/cmd/ejson/actions.go
@@ -17,7 +17,7 @@ func encryptAction(args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(os.Stderr, "Wrote %d bytes to %s.\n", n, filePath)
+		fmt.Printf("Wrote %d bytes to %s.\n", n, filePath)
 	}
 	return nil
 }
@@ -58,7 +58,7 @@ func keygenAction(args []string, keydir string, wFlag bool) error {
 		}
 		fmt.Println(pub)
 	} else {
-		fmt.Fprintf(os.Stderr, "Public Key:\n%s\nPrivate Key:\n%s\n", pub, priv)
+		fmt.Printf("Public Key:\n%s\nPrivate Key:\n%s\n", pub, priv)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #55 
Closes #58

I agree that both of these cases should be stdout rather than stderr: neither are error cases, nor must either be separated from a stdout stream that's useful to redirect elsewhere.