### PR TITLE
Issues with cli.helpPrinter signature when go getting

### DIFF
--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
 	"syscall"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func execManpage(sec, page string) {
@@ -23,7 +24,7 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Rather than using the built-in help printer, display the bundled manpages.
-	cli.HelpPrinter = func(templ string, data interface{}) {
+	cli.HelpPrinter = func(_ io.Writer, templ string, data interface{}) {
 		if cmd, ok := data.(cli.Command); ok {
 			switch cmd.Name {
 			case "encrypt", "decrypt", "keygen":

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/Shopify/ejson
 go 1.12
 
 require (
-	github.com/codegangsta/cli v0.0.0-20141123214656-9908e96513e5
 	github.com/dustin/gojson v0.0.0-20130803055424-057ac0edc14e
 	github.com/smartystreets/goconvey v0.0.0-20141010202006-90f2eae17a8b
+	github.com/urfave/cli v1.20.0
 	golang.org/x/crypto v0.0.0-20161025161229-ca7e7f10cb9f
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/codegangsta/cli v0.0.0-20141123214656-9908e96513e5 h1:yusLMk8a278LiVcrJRwq8S5Anl5R9HqauOTIfpEqvGc=
-github.com/codegangsta/cli v0.0.0-20141123214656-9908e96513e5/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
 github.com/dustin/gojson v0.0.0-20130803055424-057ac0edc14e h1:6sSV6EV1MwaHjQwpyC1ZK/f1gZJ51k9E0AcCp1wHVWQ=
 github.com/dustin/gojson v0.0.0-20130803055424-057ac0edc14e/go.mod h1:mPKfmRa823oBIgl2r20LeMSpTAteW5j7FLkc0vjmzyQ=
 github.com/smartystreets/goconvey v0.0.0-20141010202006-90f2eae17a8b h1:YS0kl27nTXgpQOlQJqkqt/mvj4LxlzZqbu4lqzQ/h+U=
 github.com/smartystreets/goconvey v0.0.0-20141010202006-90f2eae17a8b/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 golang.org/x/crypto v0.0.0-20161025161229-ca7e7f10cb9f h1:ncuMhm5zJcM+VAlAYs8f767hNJwBSLVGHjiEwFZvut8=
 golang.org/x/crypto v0.0.0-20161025161229-ca7e7f10cb9f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
# The Problem

When fetching ejson via `go get github.com/Shopify/ejson/cmd/ejson` we received the following error:

```
[2019-05-28T18:52:07Z] # github.com/Shopify/ejson/cmd/ejson
[2019-05-28T18:52:07Z] src/github.com/Shopify/ejson/cmd/ejson/main.go:26:18: \
  cannot use func literal (type func(string, interface {})) as type cli.helpPrinter in assignment
```

# The Solution

* Bump the version of `cli` to the latest tag
* Fix up the custom help command to match the func type
* Update references for `codegangsta/cli` to `urfave/cli` since this is where the lib lives now.