### PR TITLE
Move FreeBSD build instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,12 @@ Take a look at `dev.yml`, which enumerates the development dependencies. In most
 need a modern Go and a modern Ruby. This file also lists the major development tasks (building,
 running tests).
 
+## Building on FreeBSD
+
+Building on FreeBSD requires the GNU tools: `bash`, `gmake` and `gtar`.
+
+You can install them with `pkg install bash gmake gtar`. Then use `gmake` in place of `make`.
+
 ## Contributions
 
 We're happy to accept bugfixes and other PRs, but be aware that we are very conservative about

--- a/README.md
+++ b/README.md
@@ -143,9 +143,3 @@ of:
 ## See also
 
 * If you use Capistrano for deployment you can use [capistrano-ejson](https://github.com/Shopify/capistrano-ejson) to automatically decrypt the secrets on deploy.
-
-## Building on FreeBSD
-
-Building on FreeBSD requires the GNU tools: `bash`, `gmake` and `gtar`.
-
-You can install them with `pkg install bash gmake gtar`. Then use `gmake` in place of `make`.


### PR DESCRIPTION
I realize now it makes more sense to have build instructions in CONTRIBUTING.md rather than README.md.