### PR TITLE
Add `gnu-tar` as a dev dependency 

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,6 +1,8 @@
 name: ejson
 
 up:
+  - homebrew:
+    - gnu-tar
   - ruby: 2.6.0
   - go:
       version: 1.12.5


### PR DESCRIPTION
Running `make all` would fail with a fpm error:
```
bundle exec fpm \
		-t deb \
		-s dir \
		--name="ejson" \
		--version="1.2.1" \
		--package="pkg/ejson_1.2.1_amd64.deb" \
		--license=MIT \
		--category=admin \
		--no-depends \
		--no-auto-depends \
		--architecture=amd64 \
		--maintainer="Shopify <admins@shopify.com>" \
		--description="utility for managing a collection of secrets in source control. Secrets are encrypted using public key, elliptic curve cryptography." \
		--url="https://github.com/Shopify/ejson" \
		./build/man/=/usr/share/man/ \
		./build/bin/linux-amd64=/usr/bin/ejson
Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag {:level=>:warn}
Process failed: tar failed (exit code 1). Full command was:["tar", "-C", "/var/folders/l2/5wvtps5n1zjb9_bm_8s9m5q00000gn/T/package-deb-build-17bf473b24dc93ae688b16c24f3a402b1315ee53b91db126016a642b9ef4/control", "-zcf", "/var/folders/l2/5wvtps5n1zjb9_bm_8s9m5q00000gn/T/package-deb-build-17bf473b24dc93ae688b16c24f3a402b1315ee53b91db126016a642b9ef4/control.tar.gz", "--owner=0", "--group=0", "--numeric-owner", "."] {:level=>:error}
make: *** [pkg/ejson_1.2.1_amd64.deb] Error 1
```

I dug into it a bit and found tar bundled with macOS does not support the flag `"--owner=0"`
