### PR TITLE
Fix README command to generate keypair with write flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Private Key:
 ```
 
 ```
-$ ./ejson keygen -w
+$ ejson keygen -w
 53393332c6c7c474af603c078f5696c8fe16677a09a711bba299a6c1c1676a59
 $ cat /opt/ejson/keys/5339*
 888a4291bef9135729357b8c70e5a62b0bbe104a679d829cdbe56d46a4481aaf


### PR DESCRIPTION
### Problem
There is an incorrect command in the README under Step 2 of Workflow to generate a keypair.

<img width="680" alt="Screen Shot 2020-04-06 at 4 55 51 PM" src="https://user-images.githubusercontent.com/11142576/78605354-5bf50d00-7829-11ea-9d5e-78e04fa2ef55.png">

### Current behaviour
`./ejson keygen -w` will give error `no such file or directory: ./ejson`

### Expected behaviour
It should run the `ejson keygen` command with the write flag `-w`