### PR TITLE
Update dependencies (ruby and rdiscount)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       insist
       mustache (= 0.99.8)
       stud
-    rdiscount (2.2.0.1)
+    rdiscount (2.2.0.2)
     ronn (0.7.3)
       hpricot (>= 0.8.2)
       mustache (>= 0.7.0)

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: ejson
 up:
   - homebrew:
     - gnu-tar
-  - ruby: 2.7.0
+  - ruby: 2.7.2
   - go:
       version: 1.14.3
       modules: true


### PR DESCRIPTION
Trying to install it on MacOS Big Sur shows the following problem:

```
┃┃ Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
┃┃     current directory: /Users/plentz/.gem/ruby/2.7.2/gems/rdiscount-2.2.0.1/ext
┃┃ /opt/rubies/2.7.2/bin/ruby -I /opt/rubies/2.7.2/lib/ruby/2.7.0 -r ./siteconf20210117-58583-mrp5in.rb extconf.rb
```

[rdiscount `2.2.0.2` fixed the compilation error.](https://github.com/davidfstr/rdiscount/blob/master/CHANGELOG.md) 

<details>
  <summary>Click to expand</summary>
  
```
➜  ejson git:(master) ✗ dev up
⭑ Global System Setup
┏━━ 👩‍💻  1/5 Homebrew setup ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ 𝒾 Remove OpenSSL 1.0-linked Rubies
┃ ✓ Remove OpenSSL 1.0-linked Rubies: done
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.12s) ━━
┏━━ 👩‍💻  2/5 Homebrew Packages ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ ⭑ install homebrew
┃ ⭑ upgrade bash
┃ ⭑ unlink or uninstall conflicting homebrew packages
┃ ⭑ check for deprecated homebrew packages in dev.yml
┃ ⭑ install packages
┃ ⭑ link packages
┃ ⭑ upgrade packages
┃ ⭑ check for stale library links
┃ 𝒾 generate shadowenv for homebrew
┃ ✓ generate shadowenv for homebrew: done
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.02s) ━━
┏━━ 👩‍💻  3/5 Ruby ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ ⭑ Ruby OS version
┃ ⭑ install ruby 2.7.2
┃ 𝒾 generate shadowenv for ruby
┃ ✓ generate shadowenv for ruby: done
┃ ⭑ upgrade rubygems
┃ ⭑ check .ruby-version
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.06s) ━━
┏━━ 👩‍💻  4/5 Golang ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ 𝒾 install go 1.14.3
┃                                                                                                                                                                                                                                                                                                                                                                     100%
┃ ✓ install go 1.14.3: done
┃ 𝒾 generate shadowenv for go
┃ ✓ generate shadowenv for go: done
┃ 𝒾 install golint
┃ ✓ install golint: done
┃ 𝒾 install errcheck
┃ ✓ install errcheck: done
┃ 𝒾 install or upgrade dep
┃ running brew update
┃ We need to install 1 package(s): dep
┃ INSTALL package: dep
┃┏━━ Running `brew install dep` ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃┃    Warning: dep has been deprecated because it has an archived upstream repository!
┃┃ 
┃┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (6.48s) ━━
┃ ✓ install or upgrade dep: done
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (32.05s) ━━
┏━━ 👩‍💻  5/5 Bundler ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ 𝒾 install bundler
┃ Running gem install bundler -v 1.16.6
┃ ✓ install bundler: done
┃ ⭑ ensure gemfile exists
┃ ⭑ update tokens in bundler config
┃ ⭑ bundle with 1.16.6
┃ ⭑ assert foreman not present in gemfile
┃ ⭑ set local bundler configs
┃ ⭑ fix cache
┃ ⭑ prune gems with invalid native libraries
┃┏━━ Running `bundle install` ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃┃ Installing cabin 0.9.0
┃┃ Installing backports 3.17.2
┃┃ Installing clamp 1.0.1
┃┃ Installing ffi 1.13.1 with native extensions
┃┃ Installing json 1.8.6 with native extensions
┃┃ Installing insist 1.0.0
┃┃ Installing mustache 0.99.8
┃┃ Installing stud 0.0.23
┃┃ Installing io-like 0.3.1
┃┃ Installing hpricot 0.8.6 with native extensions
┃┃ Installing rdiscount 2.2.0.1 with native extensions
┃┃ Installing arr-pm 0.0.10
┃┃ Installing pleaserun 0.0.31
┃┃ Installing childprocess 0.9.0
┃┃ Installing ruby-xz 0.2.3
┃┃ Installing fpm 1.11.0
┃┃ Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
┃┃     current directory: /Users/plentz/.gem/ruby/2.7.2/gems/rdiscount-2.2.0.1/ext
┃┃ /opt/rubies/2.7.2/bin/ruby -I /opt/rubies/2.7.2/lib/ruby/2.7.0 -r ./siteconf20210117-58583-mrp5in.rb extconf.rb
┃┃ checking for random()... yes
┃┃ checking for srandom()... yes
┃┃ checking for rand()... yes
┃┃ checking for srand()... yes
┃┃ checking size of unsigned long... 8
┃┃ checking size of unsigned int... 4
┃┃ checking size of unsigned int... 4
┃┃ checking size of unsigned short... 2
┃┃ creating Makefile
┃┃ current directory: /Users/plentz/.gem/ruby/2.7.2/gems/rdiscount-2.2.0.1/ext
┃┃ make "DESTDIR=" clean
┃┃ current directory: /Users/plentz/.gem/ruby/2.7.2/gems/rdiscount-2.2.0.1/ext
┃┃ make "DESTDIR="
┃┃ compiling Csio.c
┃┃ compiling amalloc.c
┃┃ amalloc.c:23:1: warning: function 'die' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
┃┃ {
┃┃ ^
┃┃ amalloc.c:39:14: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃     if ( ret = calloc(count + sizeof(struct alist) + sizeof(int), size) ) {
┃┃          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ amalloc.c:39:14: note: place parentheses around the assignment to silence this warning
┃┃     if ( ret = calloc(count + sizeof(struct alist) + sizeof(int), size) ) {
┃┃              ^
┃┃          (                                                             )
┃┃ amalloc.c:39:14: note: use '==' to turn this assignment into an equality comparison
┃┃     if ( ret = calloc(count + sizeof(struct alist) + sizeof(int), size) ) {
┃┃              ^
┃┃              ==
┃┃ amalloc.c:76:10: warning: passing 'const char [46]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             die("goddam: corrupted memory block %d in free()!\n", p2->index);
┃┃                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ amalloc.c:22:11: note: passing argument to parameter 'msg' here
┃┃ die(char *msg, int index)
┃┃           ^
┃┃ amalloc.c:95:10: warning: passing 'const char [49]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             die("goddam: corrupted memory block %d in realloc()!\n", p2->index);
┃┃                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ amalloc.c:22:11: note: passing argument to parameter 'msg' here
┃┃ die(char *msg, int index)
┃┃           ^
┃┃ 4 warnings generated.
┃┃ compiling basename.c
┃┃ compiling css.c
┃┃ css.c:81:28: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
┃┃     written = (size > 0) ? fwrite(res,1,size,f) : 0;
┃┃             ~              ^~~~~~~~~~~~~~~~~~~~
┃┃ 1 warning generated.
┃┃ compiling docheader.c
┃┃ compiling dumptree.c
┃┃ dumptree.c:23:29: warning: returning 'const char [11]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case WHITESPACE: return "whitespace";
┃┃                             ^~~~~~~~~~~~
┃┃ dumptree.c:24:29: warning: returning 'const char [5]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case CODE      : return "code";
┃┃                             ^~~~~~
┃┃ dumptree.c:25:29: warning: returning 'const char [6]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case QUOTE     : return "quote";
┃┃                             ^~~~~~~
┃┃ dumptree.c:26:29: warning: returning 'const char [7]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case MARKUP    : return "markup";
┃┃                             ^~~~~~~~
┃┃ dumptree.c:27:29: warning: returning 'const char [5]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case HTML      : return "html";
┃┃                             ^~~~~~
┃┃ dumptree.c:28:29: warning: returning 'const char [3]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     cas
┃┃ e DL        : return "dl";
┃┃                             ^~~~
┃┃ dumptree.c:29:29: warning: returning 'const char [3]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case UL        : return "ul";
┃┃                             ^~~~
┃┃ dumptree.c:30:29: warning: returning 'const char [3]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case OL        : return "ol";
┃┃                             ^~~~
┃┃ dumptree.c:31:29: warning: returning 'const char [5]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case LISTITEM  : return "item";
┃┃                             ^~~~~~
┃┃ dumptree.c:32:29: warning: returning 'const char [7]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case HDR       : return "header";
┃┃                             ^~~~~~~~
┃┃ dumptree.c:33:29: warning: returning 'const char [3]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case HR        : return "hr";
┃┃                             ^~~~
┃┃ dumptree.c:34:29: warning: returning 'const char [6]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case TABLE     : return "table";
┃┃                             ^~~~~~~
┃┃ dumptree.c:35:29: warning: returning 'const char [7]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case SOURCE    : return "source";
┃┃                             ^~~~~~~~
┃┃ dumptree.c:36:29: warning: returning 'const char [6]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case STYLE     : return "style";
┃┃                             ^~~~~~~
┃┃ dumptree.c:37:29: warning: returning 'const char [14]' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     default        : return "mystery node!";
┃┃                             ^~~~~~~~~~~~~~~
┃┃ dumptree.c:104:33: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     static char *Begin[] = { 0, "P", "center" };
┃┃                                 ^~~
┃┃ dumptree.c:104:38: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     static char *Begin[] = { 0, "P", "center" };
┃┃                                      ^~~~~~~~
┃┃ 17 warnings generated.
┃┃ compiling emmatch.c
┃┃ emmatch.c:113:20: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃     case 2: if ( e = empair(f,first,last,match=2) )
┃┃                  ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ emmatch.c:113:20: note: place parentheses around the assignment to silence this warning
┃┃     case 2: if ( e = empair(f,first,last,match=2) )
┃┃                    ^
┃┃                  (                               )
┃┃ emmatch.c:113:20: note: use '==' to turn this assignment into an equality comparison
┃┃     case 2: if ( e = empair(f,first,last,match=2) )
┃┃                    ^
┃┃                    ==
┃┃ 1 warning generated.
┃┃ compiling flags.c
┃┃ flags.c:10:27: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOLINKS,        "!LINKS" },
┃┃                           ^~~~~~~~
┃┃ flags.c:11:27: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOIMAGE,        "!IMAGE" },
┃┃                           ^~~~~~~~
┃┃ flags.c:12:27: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOPANTS,        "!PANTS" },
┃┃                 ^~~~~~~~
┃┃ flags.c:13:27: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOHTML,         "!HTML" },
┃┃                           ^~~~~~~
┃┃ flags.c:14:27: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_STRICT,         "STRICT" },
┃┃                           ^~~~~~~~
┃┃ flags.c:15:27: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_TAGTEXT,        "TAGTEXT" },
┃┃                           ^~~~~~~~~
┃┃ flags.c:16:27: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NO_EXT,         "!EXT" },
┃┃                           ^~~~~~
┃┃ flags.c:17:27: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_CDATA,          "CDATA" },
┃┃                           ^~~~~~~
┃┃ flags.c:18:27: warning: initializing 'char *' with an expression of type 'const char [13]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOSUPERSCRIPT,  "!SUPERSCRIPT" },
┃┃                           ^~~~~~~~~~~~~~
┃┃ flags.c:19:27: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NORELAXED,      "!RELAXED" },
┃┃                           ^~~~~~~~~~
┃┃ flags.c:20:27: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOTABLES,       "!TABLES" },
┃┃                           ^~~~~~~~~
┃┃ flags.c:21:27: warning: initializing 'char *' with an expression of type 'const char [15]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOSTRIKETHROUGH,"!STRIKETHROUGH" },
┃┃                           ^~~~~~~~~~~~~~~~
┃┃ flags.c:22:27: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_TOC,            "TOC" },
┃┃                           ^~~~~
┃┃ flags.c:23:27: warning: initializing 'char *' with an expression of type 'const char [13]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_1_COMPAT,       "MKD_1_COMPAT" },
┃┃                           ^~~~~~~~~~~~~~
┃┃ flags.c:24:27: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_AUTOLINK,       "AUTOLINK" },
┃┃                           ^~~~~~~~~~
┃┃ flags.c:25:27: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_SAFELINK,       "SAFELINK" },
┃┃                           ^~~~~~~~~~
┃┃ flags.c:26:27: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOHEADER,       "!HEADER" },
┃┃                           ^~~~~~~~~
┃┃ flags.c:27:27: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_TABSTOP,        "TABSTOP" },
┃┃                           ^~~~~~~~~
┃┃ flags.c:28:27: warning: initializing 'char *' with an expression of type 'const char [10]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NODIVQUOTE,     "!DIVQUOTE" },
┃┃                           ^~~~~~~~~~~
┃┃ flags.c:29:27: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOALPHALIST,    "!ALPHALIST" },
┃┃                           ^~~~~~~~~~~~
┃┃ flags.c:30:27: warning: init
┃┃ ializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NODLIST,        "!DLIST" },
┃┃                           ^~~~~~~~
┃┃ flags.c:31:27: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_EXTRA_FOOTNOTE, "FOOTNOTE" },
┃┃                           ^~~~~~~~~~
┃┃ flags.c:32:27: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NOSTYLE,        "!STYLE" },
┃┃                           ^~~~~~~~
┃┃ flags.c:33:27: warning: initializing 'char *' with an expression of type 'const char [12]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_NODLDISCOUNT,   "!DLDISCOUNT" },
┃┃                           ^~~~~~~~~~~~~
┃┃ flags.c:34:27: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_DLEXTRA,        "DLEXTRA" },
┃┃                           ^~~~~~~~~
┃┃ flags.c:35:27: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_FENCEDCODE,     "FENCEDCODE" },
┃┃                           ^~~~~~~~~~~~
┃┃ flags.c:36:27: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_IDANCHOR,       "IDANCHOR" },
┃┃                           ^~~~~~~~~~
┃┃ flags.c:37:27: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_GITHUBTAGS,     "GITHUBTAGS" },
┃┃                           ^~~~~~~~~~~~
┃┃ flags.c:38:29: warning: initializing 'char *' with an expression of type 'const char [17]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { MKD_URLENCODEDANCHOR, "URLENCODEDANCHOR" },
┃┃                             ^~~~~~~~~~~~~~~~~~
┃┃ flags.c:55:11: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃         if ( not = (*name == '!') ) {
┃┃              ~~~~^~~~~~~~~~~~~~~~
┃┃ flags.c:55:11: note: place parentheses around the assignment to silence this warning
┃┃         if ( not = (*name == '!') ) {
┃┃                  ^
┃┃              (                   )
┃┃ flags.c:55:11: note: use '==' to turn this assignment into an equality comparison
┃┃         if ( not = (*name == '!') ) {
┃┃                  ^
┃┃                  ==
┃┃ flags.c:52:17: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
┃┃     for (i=0; i < NR(flagnames); i++) {
┃┃               ~ ^ ~~~~~~~~~~~~~
┃┃ 31 warnings generated.
┃┃ compiling generate.c
┃┃ generate.c:268:14: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring("&amp;", f);
┃┃                     ^~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:270:14: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring("&lt;", f);
┃┃                     ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:272:14: warning: passing 'const char [4]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring("%22", f);
┃┃                     ^~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:276:14: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring("  ", f);
┃┃                     ^~~~
┃┃ generate.c:149:15: note: passing argument 
┃┃ to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:278:17: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qprintf(f, "%%%02X", c);
┃┃                        ^~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:351:28: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
┃┃                 S(ref->title) = (e-title)-2;
┃┃                               ~ ~~~~~~~~~^~
┃┃ generate.c:498:17: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     _aprotocol( "https:" ), 
┃┃                 ^~~~~~~~
┃┃ generate.c:497:25: note: expanded from macro '_aprotocol'
┃┃ #define _aprotocol(x)   { x, (sizeof x)-1 }
┃┃                           ^
┃┃ generate.c:499:17: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     _aprotocol( "http:" ), 
┃┃                 ^~~~~~~
┃┃ generate.c:497:25: note: expanded from macro '_aprotocol'
┃┃ #define _aprotocol(x)   { x, (sizeof x)-1 }
┃┃                           ^
┃┃ generate.c:500:17: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     _aprotocol( "news:" ),
┃┃                 ^~~~~~~
┃┃ generate.c:497:25: note: expanded from macro '_aprotocol'
┃┃ #define _aprotocol(x)   { x, (sizeof x)-1 }
┃┃                           ^
┃┃ generate.c:501:17: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     _aprotocol( "ftp:" ), 
┃┃                 ^~~~~~
┃┃ generate.c:497:25: note: expanded from macro '_aprotocol'
┃┃ #define _aprotocol(x)   { x, (sizeof x)-1 }
┃┃                           ^
┃┃ generate.c:513:29: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
┃┃     for (i=0, p=protocol; i < NRPROTOCOLS; i++, p++)
┃┃                           ~ ^ ~~~~~~~~~~~
┃┃ generate.c:537:35: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃ static linkytype imaget = { 0, 0, "<img src=\"", "\"",
┃┃                                   ^~~~~~~~~~~~~
┃┃ generate.c:537:50: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃ static linkytype imaget = { 0, 0, "<img src=\"", "\"",
┃┃                                                  ^~~~
┃┃ generate.c:538:12: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                              1, " alt=\"", "\" />", MKD_NOIMAGE|MKD_TAGTEXT, IS_URL };
┃┃                                 ^~~~~~~~~
┃┃ generate.c:538:23: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                              1, " alt=\"", "\" />", MKD_NOIMAGE|MKD_TAGTEXT, IS_URL };
┃┃                                            ^~~~~~~
┃┃ generate.c:539:35: warning: initializing 'char *' with an expression of type 'const char [10]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃ static linkytype linkt  = { 0, 0, "<a href=\"", "\"",
┃┃                                   ^~~~~~~~~~~~
┃┃ generate.c:539:49: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃ static linkytype linkt  = { 0, 0, "<a href=\"", "\"",
┃┃                                                 ^~~~
┃┃ generate.c:540:33: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                              0, ">", "</a>"
┃┃ , MKD_NOLINKS, IS_URL };
┃┃                                 ^~~
┃┃ generate.c:540:38: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                              0, ">", "</a>", MKD_NOLINKS, IS_URL };
┃┃                                      ^~~~~~
┃┃ generate.c:550:7: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "id:", 3, "<span id=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃       ^~~~~
┃┃ generate.c:550:17: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "id:", 3, "<span id=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                 ^~~~~~~~~~~~~
┃┃ generate.c:550:32: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "id:", 3, "<span id=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                ^~~~
┃┃ generate.c:550:41: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "id:", 3, "<span id=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                         ^~~
┃┃ generate.c:550:46: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "id:", 3, "<span id=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                              ^~~~~~~~~
┃┃ generate.c:551:7: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "raw:", 4, 0, 0, 0, 0, 0, MKD_NOHTML, 0 },
┃┃       ^~~~~~
┃┃ generate.c:552:7: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "lang:", 5, "<span lang=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃       ^~~~~~~
┃┃ generate.c:552:19: warning: initializing 'char *' with an expression of type 'const char [13]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "lang:", 5, "<span lang=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                   ^~~~~~~~~~~~~~~
┃┃ generate.c:552:36: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "lang:", 5, "<span lang=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                    ^~~~
┃┃ generate.c:552:45: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "lang:", 5, "<span lang=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                             ^~~
┃┃ generate.c:552:50: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "lang:", 5, "<span lang=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                                  ^~~~~~~~~
┃┃ generate.c:553:7: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "abbr:", 5, "<abbr title=\"", "\"", 0, ">", "</abbr>", 0, 0 },
┃┃       ^~~~~~~
┃┃ generate.c:553:19: warning: initializing 'char *' with an expression of type 'const char [14]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "abbr:", 5, "<abbr title=\"", "\"", 0, ">", "</abbr>", 0, 0 },
┃┃                   ^~~~~~~~~~~~~~~~
┃┃ generate.c:553:37: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "abbr:", 5, "<abbr title=\"", "\"", 0, ">", "</abbr>", 0, 0 },
┃┃                                     ^~~~
┃┃ generate.c:553:46: warning: initializing 'char *' with an 
┃┃ expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "abbr:", 5, "<abbr title=\"", "\"", 0, ">", "</abbr>", 0, 0 },
┃┃                                              ^~~
┃┃ generate.c:553:51: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "abbr:", 5, "<abbr title=\"", "\"", 0, ">", "</abbr>", 0, 0 },
┃┃                                                   ^~~~~~~~~
┃┃ generate.c:554:7: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "class:", 6, "<span class=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃       ^~~~~~~~
┃┃ generate.c:554:20: warning: initializing 'char *' with an expression of type 'const char [14]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "class:", 6, "<span class=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                    ^~~~~~~~~~~~~~~~
┃┃ generate.c:554:38: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "class:", 6, "<span class=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                      ^~~~
┃┃ generate.c:554:47: warning: initializing 'char *' with an expression of type 'const char [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "class:", 6, "<span class=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                               ^~~
┃┃ generate.c:554:52: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "class:", 6, "<span class=\"", "\"", 0, ">", "</span>", 0, 0 },
┃┃                                                    ^~~~~~~~~
┃┃ generate.c:567:30: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
┃┃     for ( i=0, r=specials; i < NR(specials); i++,r++ ) {
┃┃                            ~ ^ ~~~~~~~~~~~~
┃┃ generate.c:589:19: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
┃┃             puturl(edit, strlen(edit), f, 0);
┃┃             ~~~~~~       ^~~~~~~~~~~~
┃┃ generate.c:615:12: warning: returning 'const char *' from a function with result type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     return p->ref_prefix ? p->ref_prefix : "fn";
┃┃            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:632:13: warning: passing 'const char [64]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, "<sup id=\"%sref:%d\"><a href=\"#%s:%d\" rel=\"footnote\">%d</a></sup>",
┃┃                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:650:19: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃     else if ( tag = pseudo(ref->link) ) {
┃┃               ~~~~^~~~~~~~~~~~~~~~~~~
┃┃ generate.c:650:19: note: place parentheses around the assignment to silence this warning
┃┃     else if ( tag = pseudo(ref->link) ) {
┃┃                   ^
┃┃               (                      )
┃┃ generate.c:650:19: note: use '==' to turn this assignment into an equality comparison
┃┃     else if ( tag = pseudo(ref->link) ) {
┃┃                   ^
┃┃                   ==
┃┃ generate.c:673:35: warning: passing 'const char [13]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             if ( ref->height ) Qprintf(f," height=\"%d\"", ref->height);
┃┃                                          ^~~~~~~~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:674:35: warning: passing 'const char [12]' to parameter of type 'char *' disca
┃┃ rds qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             if ( ref->width ) Qprintf(f, " width=\"%d\"", ref->width);
┃┃                                          ^~~~~~~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:678:14: warning: passing 'const char [9]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring(" title=\"", f);
┃┃                     ^~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:744:12: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃                 if ( ref = bsearch(&key, T(f->footnotes->note),
┃┃                      ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:744:12: note: place parentheses around the assignment to silence this warning
┃┃                 if ( ref = bsearch(&key, T(f->footnotes->note),
┃┃                          ^
┃┃                      (
┃┃ generate.c:744:12: note: use '==' to turn this assignment into an equality comparison
┃┃                 if ( ref = bsearch(&key, T(f->footnotes->note),
┃┃                          ^
┃┃                          ==
┃┃ generate.c:773:25: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case '&':   Qstring("&amp;", f); break;
┃┃                         ^~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:774:25: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case '>':   Qstring("&gt;", f); break;
┃┃                         ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:775:25: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     case '<':   Qstring("&lt;", f); break;
┃┃                         ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:791:10: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("&#", f);
┃┃                 ^~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:792:13: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, COINTOSS() ? "x%02x;" : "%02d;", *((unsigned char*)(s++)) );
┃┃                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ ./config.h:12:20: note: expanded from macro 'COINTOSS'
┃┃ #define COINTOSS() (random()&1)
┃┃                    ^
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:856:14: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring("  ", f);
┃┃                     ^~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:868:13: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("<del>", f);
┃┃             ^~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:870:13: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("</del>", f);
┃┃             ^~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:885:13: warning: passing
┃┃  'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("<code>", f);
┃┃             ^~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:887:13: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("</code>", f);
┃┃             ^~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:964:10: warning: passing 'const char [10]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("<a href=\"", f);
┃┃                 ^~~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:967:13: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             mangle("mailto:", 7, f);
┃┃                    ^~~~~~~~~
┃┃ generate.c:785:14: note: passing argument to parameter 's' here
┃┃ mangle(char *s, int len, MMIOT *f)
┃┃              ^
┃┃ generate.c:970:10: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("\">", f);
┃┃                 ^~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:972:10: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("</a>", f);
┃┃                 ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:979:10: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("</a>", f);
┃┃                 ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1087:17: warning: passing 'const char [9]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qprintf(f, "&r%cquo;", typeofquote);
┃┃                        ^~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1093:13: warning: passing 'const char [9]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, "&l%cquo;", typeofquote);
┃┃                    ^~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1113:18: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
┃┃     if ( !(len = strlen(s)) )
┃┃                ~ ^~~~~~~~~
┃┃ generate.c:1135:13: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'s|",      "rsquo",  0 },
┃┃             ^~~~~
┃┃ generate.c:1135:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'s|",      "rsquo",  0 },
┃┃                         ^~~~~~~
┃┃ generate.c:1136:13: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'t|",      "rsquo",  0 },
┃┃             ^~~~~
┃┃ generate.c:1136:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'t|",      "rsquo",  0 },
┃┃                         ^~~~~~~
┃┃ generate.c:1137:13: warning: initializing 'char *' with an expression of type 'const char [5]' discards
┃┃  qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'re|",     "rsquo",  0 },
┃┃             ^~~~~~
┃┃ generate.c:1137:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'re|",     "rsquo",  0 },
┃┃                         ^~~~~~~
┃┃ generate.c:1138:13: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'ll|",     "rsquo",  0 },
┃┃             ^~~~~~
┃┃ generate.c:1138:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'ll|",     "rsquo",  0 },
┃┃                         ^~~~~~~
┃┃ generate.c:1139:13: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'ve|",     "rsquo",  0 },
┃┃             ^~~~~~
┃┃ generate.c:1139:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'ve|",     "rsquo",  0 },
┃┃                         ^~~~~~~
┃┃ generate.c:1140:13: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'m|",      "rsquo",  0 },
┃┃             ^~~~~
┃┃ generate.c:1140:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'m|",      "rsquo",  0 },
┃┃                         ^~~~~~~
┃┃ generate.c:1141:13: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'d|",      "rsquo",  0 },
┃┃             ^~~~~
┃┃ generate.c:1141:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '\'', "'d|",      "rsquo",  0 },
┃┃                         ^~~~~~~
┃┃ generate.c:1142:13: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '-',  "---",      "mdash",  2 },
┃┃             ^~~~~
┃┃ generate.c:1142:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '-',  "---",      "mdash",  2 },
┃┃                         ^~~~~~~
┃┃ generate.c:1143:13: warning: initializing 'char *' with an expression of type 'const char [3]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '-',  "--",       "ndash",  1 },
┃┃             ^~~~
┃┃ generate.c:1143:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '-',  "--",       "ndash",  1 },
┃┃                         ^~~~~~~
┃┃ generate.c:1144:13: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '.',  "...",      "hellip", 2 },
┃┃             ^~~~~
┃┃ generate.c:1144:25: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '.',  "...",      "hellip", 2 },
┃┃                         ^~~~~~~~
┃┃ generate.c:1145:13: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '.',  ". . .",    "hellip", 4 },
┃┃             ^~~~~~~
┃┃ generate.c:1145:25: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '.',  ". . .",    "hellip", 4 },
┃┃                         ^~~~~~~~
┃┃ generate.c:1146:13: warning: initializing 'char *' wi
┃┃ th an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '(',  "(c)",      "copy",   2 },
┃┃             ^~~~~
┃┃ generate.c:1146:25: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '(',  "(c)",      "copy",   2 },
┃┃                         ^~~~~~
┃┃ generate.c:1147:13: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '(',  "(r)",      "reg",    2 },
┃┃             ^~~~~
┃┃ generate.c:1147:25: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '(',  "(r)",      "reg",    2 },
┃┃                         ^~~~~
┃┃ generate.c:1148:13: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '(',  "(tm)",     "trade",  3 },
┃┃             ^~~~~~
┃┃ generate.c:1148:25: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '(',  "(tm)",     "trade",  3 },
┃┃                         ^~~~~~~
┃┃ generate.c:1149:13: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '3',  "|3/4|",    "frac34", 2 },
┃┃             ^~~~~~~
┃┃ generate.c:1149:25: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '3',  "|3/4|",    "frac34", 2 },
┃┃                         ^~~~~~~~
┃┃ generate.c:1150:13: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '3',  "|3/4ths|", "frac34", 2 },
┃┃             ^~~~~~~~~~
┃┃ generate.c:1150:25: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '3',  "|3/4ths|", "frac34", 2 },
┃┃                         ^~~~~~~~
┃┃ generate.c:1151:13: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '1',  "|1/2|",    "frac12", 2 },
┃┃             ^~~~~~~
┃┃ generate.c:1151:25: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '1',  "|1/2|",    "frac12", 2 },
┃┃                         ^~~~~~~~
┃┃ generate.c:1152:13: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '1',  "|1/4|",    "frac14", 2 },
┃┃             ^~~~~~~
┃┃ generate.c:1152:25: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '1',  "|1/4|",    "frac14", 2 },
┃┃                         ^~~~~~~~
┃┃ generate.c:1153:13: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '1',  "|1/4th|",  "frac14", 2 },
┃┃             ^~~~~~~~~
┃┃ generate.c:1153:25: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '1',  "|1/4th|",  "frac14", 2 },
┃┃                         ^~~~~~~~
┃┃ generate.c:1154:13: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { '&',  "&#0;",      0,       3 },
┃┃             ^~~~~~
┃┃ generate.c:1172:14: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                 Qprintf(f, "&%s;", smarties[i].entity);
┃┃            ^~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1194:16: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                             Qstring("&ldquo;", f);
┃┃                                     ^~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1196:16: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                             Qstring("&rdquo;", f);
┃┃                                     ^~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1169:18: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
┃┃     for ( i=0; i < NRSMART; i++)
┃┃                ~ ^ ~~~~~~~
┃┃ generate.c:1285:15: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                     Qstring(tag_text(f) ? "  " : "<br/>", f);
┃┃                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:1260:21: note: expanded from macro 'tag_text'
┃┃ #define tag_text(f)     (f->flags & MKD_TAGTEXT)
┃┃                         ^
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1289:12: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                         Qstring("&gt;", f);
┃┃                                 ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1295:12: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                         Qstring("&quot;", f);
┃┃                                 ^~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1303:16: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                             Qstring("![", f);
┃┃                                     ^~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1341:12: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                         Qstring("<sup>",f);
┃┃                                 ^~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1342:35: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                         ___mkd_reparse(sup, len, 0, f, "()");
┃┃                                                        ^~~~
┃┃ generate.c:200:64: note: passing argument to parameter 'esc' here
┃┃ ___mkd_reparse(char *bfr, int size, int flags, MMIOT *f, char *esc)
┃┃                                                                ^
┃┃ generate.c:1343:12: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                         Qstring("</sup>", f);
┃┃                                 ^~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1380:27: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                     case '&':   Qstring("&amp;", f);
┃┃                                         ^~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *
┃┃ s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1384:17: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                                     Qstring("&lt;", f);
┃┃                                             ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1432:12: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                         Qstring("&lt;", f);
┃┃                                 ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1440:12: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                         Qstring("&amp;", f);
┃┃                                 ^~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1470:13: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, "<h%d", pp->hnumber);
┃┃                    ^~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1472:14: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring(" id=\"", f);
┃┃                     ^~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1481:14: warning: passing 'const char [10]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring("<a name=\"", f);
┃┃                     ^~~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1485:14: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qstring("\"></a>\n", f);
┃┃                     ^~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1487:13: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, "<h%d>", pp->hnumber);
┃┃                    ^~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1491:16: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qprintf(f, "</h%d>", pp->hnumber);
┃┃                ^~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1497:31: warning: initializing 'char *' with an expression of type 'const char [1]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃ static char* alignments[] = { "", " style=\"text-align:center;\"",
┃┃                               ^~
┃┃ generate.c:1497:35: warning: initializing 'char *' with an expression of type 'const char [28]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃ static char* alignments[] = { "", " style=\"text-align:center;\"",
┃┃                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:1498:7: warning: initializing 'char *' with an expression of type 'const char [26]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                                   " style=\"text-align:left;\"",
┃┃                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:1499:7: warning: initializing 'char *' with an expression of type 'const char [27]' discards qualifier
┃┃ s [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                                   " style=\"text-align:right;\"" };
┃┃                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:1515:13: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("<tr>\n", f);
┃┃             ^~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1527:13: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, "<%s%s>",
┃┃                    ^~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1530:52: warning: passing 'const char [2]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         ___mkd_reparse(T(p->text)+first, idx-first, 0, f, "|");
┃┃                                                           ^~~
┃┃ generate.c:200:64: note: passing argument to parameter 'esc' here
┃┃ ___mkd_reparse(char *bfr, int size, int flags, MMIOT *f, char *esc)
┃┃                                                                ^
┃┃ generate.c:1531:13: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, "</%s>\n", block);
┃┃                    ^~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1537:17: warning: passing 'const char [11]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qprintf(f, "<%s></%s>\n", block, block);
┃┃                        ^~~~~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1540:13: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("</tr>\n", f);
┃┃             ^~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1592:13: warning: passing 'const char [9]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("<table>\n", f);
┃┃             ^~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1593:13: warning: passing 'const char [9]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("<thead>\n", f);
┃┃             ^~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1594:24: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     hcols = splat(hdr, "th", align, 0, f);
┃┃                        ^~~~
┃┃ generate.c:1504:22: note: passing argument to parameter 'block' here
┃┃ splat(Line *p, char *block, Istring align, int force, MMIOT *f)
┃┃                      ^
┃┃ generate.c:1595:13: warning: passing 'const char [10]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("</thead>\n", f);
┃┃             ^~~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1603:13: warning: passing 'const char [9]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("<tbody>\n", f);
┃┃             ^~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1605:14: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-W
┃┃ incompatible-pointer-types-discards-qualifiers]
┃┃         splat(body, "td", align, 1, f);
┃┃                     ^~~~
┃┃ generate.c:1504:22: note: passing argument to parameter 'block' here
┃┃ splat(Line *p, char *block, Istring align, int force, MMIOT *f)
┃┃                      ^
┃┃ generate.c:1606:13: warning: passing 'const char [10]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("</tbody>\n", f);
┃┃             ^~~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1607:13: warning: passing 'const char [10]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("</table>\n", f);
┃┃             ^~~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1618:30: warning: initializing 'char *' with an expression of type 'const char [1]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     static char *Begin[] = { "", "<p>", "<p style=\"text-align:center;\">"  };
┃┃                              ^~
┃┃ generate.c:1618:34: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     static char *Begin[] = { "", "<p>", "<p style=\"text-align:center;\">"  };
┃┃                                  ^~~~~
┃┃ generate.c:1618:41: warning: initializing 'char *' with an expression of type 'const char [31]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     static char *Begin[] = { "", "<p>", "<p style=\"text-align:center;\">"  };
┃┃                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:1619:30: warning: initializing 'char *' with an expression of type 'const char [1]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     static char *End[]   = { "", "</p>","</p>" };
┃┃                              ^~
┃┃ generate.c:1619:34: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     static char *End[]   = { "", "</p>","</p>" };
┃┃                                  ^~~~~~
┃┃ generate.c:1619:41: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     static char *End[]   = { "", "</p>","</p>" };
┃┃                                         ^~~~~~
┃┃ generate.c:1651:13: warning: passing 'const char [11]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("<pre><code", f);
┃┃             ^~~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1653:15: warning: passing 'const char [9]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃       Qstring(" class=\"", f);
┃┃               ^~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1655:15: warning: passing 'const char [2]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃       Qstring("\"", f);
┃┃               ^~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1657:13: warning: passing 'const char [2]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring(">", f);
┃┃             ^~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1669:13: warning: passing 'const char [14]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Qstring("</code></pre>", f);
┃┃             ^~~~~~~~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMI
┃┃ OT *f)
┃┃               ^
┃┃ generate.c:1696:13: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, arguments ? "<%s %s>" : "<%s>", block, arguments);
┃┃                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1701:10: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("\n\n", f);
┃┃                 ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1705:14: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃          Qprintf(f, "</%s>", block);
┃┃                     ^~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1716:10: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("<dl>\n", f);
┃┃                 ^~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1720:11: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                 Qstring("<dt>", f);
┃┃                         ^~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1722:11: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                 Qstring("</dt>\n", f);
┃┃                         ^~~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1725:23: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             htmlify(p->down, "dd", p->ident, f);
┃┃                              ^~~~
┃┃ generate.c:1692:29: note: passing argument to parameter 'block' here
┃┃ htmlify(Paragraph *p, char *block, char *arguments, MMIOT *f)
┃┃                             ^
┃┃ generate.c:1729:10: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("</dl>", f);
┃┃                 ^~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1738:13: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, "<%cl", (typ==UL)?'u':'o');
┃┃                    ^~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1740:17: warning: passing 'const char [10]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             Qprintf(f, " type=\"a\"");
┃┃                        ^~~~~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1741:13: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, ">\n");
┃┃                    ^~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1744:23: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             htmlify(p->down, "li", p->ident, f);
┃┃                              ^~~~
┃┃ generate.c:1692:29: note: passing arg
┃┃ ument to parameter 'block' here
┃┃ htmlify(Paragraph *p, char *block, char *arguments, MMIOT *f)
┃┃                             ^
┃┃ generate.c:1748:13: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qprintf(f, "</%cl>\n", (typ==UL)?'u':'o');
┃┃                    ^~~~~~~~~~
┃┃ generate.c:169:25: note: passing argument to parameter 'fmt' here
┃┃ Qprintf(MMIOT *f, char *fmt, ...)
┃┃                         ^
┃┃ generate.c:1774:19: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         htmlify(p->down, p->ident ? "div" : "blockquote", p->ident, f);
┃┃                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ generate.c:1692:29: note: passing argument to parameter 'block' here
┃┃ htmlify(Paragraph *p, char *block, char *arguments, MMIOT *f)
┃┃                             ^
┃┃ generate.c:1788:10: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         Qstring("<hr />", f);
┃┃                 ^~~~~~~~
┃┃ generate.c:149:15: note: passing argument to parameter 's' here
┃┃ Qstring(char *s, MMIOT *f)
┃┃               ^
┃┃ generate.c:1822:23: warning: passing 'const char [37]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Csprintf(&m->out, "\n<div class=\"footnotes\">\n<hr/>\n<ol>\n");
┃┃                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ ./cstring.h:73:38: note: passing argument to parameter here
┃┃ extern int Csprintf(Cstring *, char *, ...);
┃┃                                      ^
┃┃ generate.c:1828:21: warning: passing 'const char [20]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                 Csprintf(&m->out, "<li id=\"%s:%d\">\n<p>",
┃┃                                   ^~~~~~~~~~~~~~~~~~~~~~~~
┃┃ ./cstring.h:73:38: note: passing argument to parameter here
┃┃ extern int Csprintf(Cstring *, char *, ...);
┃┃                                      ^
┃┃ generate.c:1831:21: warning: passing 'const char [47]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                 Csprintf(&m->out, "<a href=\"#%sref:%d\" rev=\"footnote\">&#8617;</a>",
┃┃                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ ./cstring.h:73:38: note: passing argument to parameter here
┃┃ extern int Csprintf(Cstring *, char *, ...);
┃┃                                      ^
┃┃ generate.c:1833:21: warning: passing 'const char [11]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃                 Csprintf(&m->out, "</p></li>\n");
┃┃                                   ^~~~~~~~~~~~~
┃┃ ./cstring.h:73:38: note: passing argument to parameter here
┃┃ extern int Csprintf(Cstring *, char *, ...);
┃┃                                      ^
┃┃ generate.c:1837:23: warning: passing 'const char [14]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     Csprintf(&m->out, "</ol>\n</div>\n");
┃┃                       ^~~~~~~~~~~~~~~~~
┃┃ ./cstring.h:73:38: note: passing argument to parameter here
┃┃ extern int Csprintf(Cstring *, char *, ...);
┃┃                                      ^
┃┃ 176 warnings generated.
┃┃ compiling github_flavoured.c
┃┃ compiling html5.c
┃┃ html5.c:13:20: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     mkd_define_tag("ASIDE", 0);
┃┃                    ^~~~~~~
┃┃ ./tags.h:17:27: note: passing argument to parameter here
┃┃ void mkd_define_tag(char *, int);
┃┃                           ^
┃┃ html5.c:14:20: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     mkd_define_tag("FOOTER", 0);
┃┃                    ^~~~~~~~
┃┃ ./tags.h:17:27: note: passing argument to parameter here
┃┃ void mkd_define_tag(char *, int);
┃┃                           ^
┃┃ html5.c:15:
┃┃ 20: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     mkd_define_tag("HEADER", 0);
┃┃                    ^~~~~~~~
┃┃ ./tags.h:17:27: note: passing argument to parameter here
┃┃ void mkd_define_tag(char *, int);
┃┃                           ^
┃┃ html5.c:16:20: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     mkd_define_tag("HGROUP", 0);
┃┃                    ^~~~~~~~
┃┃ ./tags.h:17:27: note: passing argument to parameter here
┃┃ void mkd_define_tag(char *, int);
┃┃                           ^
┃┃ html5.c:17:20: warning: passing 'const char [4]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     mkd_define_tag("NAV", 0);
┃┃                    ^~~~~
┃┃ ./tags.h:17:27: note: passing argument to parameter here
┃┃ void mkd_define_tag(char *, int);
┃┃                           ^
┃┃ html5.c:18:20: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     mkd_define_tag("SECTION", 0);
┃┃                    ^~~~~~~~~
┃┃ ./tags.h:17:27: note: passing argument to parameter here
┃┃ void mkd_define_tag(char *, int);
┃┃                           ^
┃┃ html5.c:19:20: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     mkd_define_tag("ARTICLE", 0);
┃┃                    ^~~~~~~~~
┃┃ ./tags.h:17:27: note: passing argument to parameter here
┃┃ void mkd_define_tag(char *, int);
┃┃                           ^
┃┃ 7 warnings generated.
┃┃ compiling markdown.c
┃┃ markdown.c:107:30: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃ static struct kw comment = { "!--", 3, 0 };
┃┃                              ^~~~~
┃┃ markdown.c:264:14: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃            if ( end = strstr(T(t->text), "-->") ) {
┃┃                 ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ markdown.c:264:14: note: place parentheses around the assignment to silence this warning
┃┃            if ( end = strstr(T(t->text), "-->") ) {
┃┃                     ^
┃┃                 (                              )
┃┃ markdown.c:264:14: note: use '==' to turn this assignment into an equality comparison
┃┃            if ( end = strstr(T(t->text), "-->") ) {
┃┃                     ^
┃┃                     ==
┃┃ markdown.c:265:32: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
┃┃                if ( nextnonblank(t, 3 + (end - T(t->text))) < S(t->text) )
┃┃                     ~~~~~~~~~~~~    ~~^~~~~~~~~~~~~~~~~~~~
┃┃ markdown.c:315:16: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃                 if ( closing = (c == '/') ) c = flogetc(&f);
┃┃                      ~~~~~~~~^~~~~~~~~~~~
┃┃ markdown.c:315:16: note: place parentheses around the assignment to silence this warning
┃┃                 if ( closing = (c == '/') ) c = flogetc(&f);
┃┃                              ^
┃┃                      (                   )
┃┃ markdown.c:315:16: note: use '==' to turn this assignment into an equality comparison
┃┃                 if ( closing = (c == '/') ) c = flogetc(&f);
┃┃                              ^
┃┃                              ==
┃┃ markdown.c:489:8: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃         if ( x=is_extra_dt(t->next, clip, flags) )
┃┃              ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ markdown.c:489:8: note: place parentheses around the assignment to silence this warning
┃┃         if ( x=is_extra_dt(t->next, clip, flags) )
┃┃               ^
┃┃              (                                  )
┃┃ markdown.c:489:8: note: use '==' to turn this assignment into an equality comparison
┃┃         if ( x=is_extra_dt(t->next, clip, flags) )
┃┃               ^
┃┃               ==
┃┃ markdown.c:502:14: warning: using the result of an assignment as a condition without
┃┃  parentheses [-Wparentheses]
┃┃     if ( ret = is_discount_dt(t,clip,flags) )
┃┃          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ markdown.c:502:14: note: place parentheses around the assignment to silence this warning
┃┃     if ( ret = is_discount_dt(t,clip,flags) )
┃┃              ^
┃┃          (                                 )
┃┃ markdown.c:502:14: note: use '==' to turn this assignment into an equality comparison
┃┃     if ( ret = is_discount_dt(t,clip,flags) )
┃┃              ^
┃┃              ==
┃┃ markdown.c:820:8: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃         char *prefix = "class";
┃┃               ^        ~~~~~~~
┃┃ markdown.c:828:12: warning: assigning to 'char *' from 'const char [3]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃             prefix="id";
┃┃                   ^~~~~
┃┃ markdown.c:830:16: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃         if ( p->ident = malloc(4+strlen(prefix)+S(q->text)) )
┃┃              ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ markdown.c:830:16: note: place parentheses around the assignment to silence this warning
┃┃         if ( p->ident = malloc(4+strlen(prefix)+S(q->text)) )
┃┃                       ^
┃┃              (                                             )
┃┃ markdown.c:830:16: note: use '==' to turn this assignment into an equality comparison
┃┃         if ( p->ident = malloc(4+strlen(prefix)+S(q->text)) )
┃┃                       ^
┃┃                       ==
┃┃ markdown.c:918:12: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃         if ( para = (text != q->next) )
┃┃              ~~~~~^~~~~~~~~~~~~~~~~~~
┃┃ markdown.c:918:12: note: place parentheses around the assignment to silence this warning
┃┃         if ( para = (text != q->next) )
┃┃                   ^
┃┃              (                       )
┃┃ markdown.c:918:12: note: use '==' to turn this assignment into an equality comparison
┃┃         if ( para = (text != q->next) )
┃┃                   ^
┃┃                   ==
┃┃ markdown.c:941:12: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃         if ( para = (q != text) ) {
┃┃              ~~~~~^~~~~~~~~~~~~
┃┃ markdown.c:941:12: note: place parentheses around the assignment to silence this warning
┃┃         if ( para = (q != text) ) {
┃┃                   ^
┃┃              (                 )
┃┃ markdown.c:941:12: note: use '==' to turn this assignment into an equality comparison
┃┃         if ( para = (q != text) ) {
┃┃                   ^
┃┃                   ==
┃┃ markdown.c:981:12: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃         if ( para = (q != text) ) {
┃┃              ~~~~~^~~~~~~~~~~~~
┃┃ markdown.c:981:12: note: place parentheses around the assignment to silence this warning
┃┃         if ( para = (q != text) ) {
┃┃                   ^
┃┃              (                 )
┃┃ markdown.c:981:12: note: use '==' to turn this assignment into an equality comparison
┃┃         if ( para = (q != text) ) {
┃┃                   ^
┃┃                   ==
┃┃ markdown.c:1272:23: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃         else if ( list_class = islist(ptr, &indent, f->flags, &list_type) ) {
┃┃                   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ markdown.c:1272:23: note: place parentheses around the assignment to silence this warning
┃┃         else if ( list_class = islist(ptr, &indent, f->flags, &list_type) ) {
┃┃                              ^
┃┃                   (                                                      )
┃┃ markdown.c:1272:23: note: use '==' to turn this assignment into an equality comparison
┃┃         else if ( list_class = islist(ptr, &indent, f->flags, &list_type) ) {
┃┃                              ^
┃┃                              ==
┃┃ 13 warnings generated.
┃┃ compiling mkdio.c
┃┃ mkdio.c:28:16: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃         if ( ret->ctx = 
┃┃ calloc(sizeof(MMIOT), 1) ) {
┃┃              ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ mkdio.c:28:16: note: place parentheses around the assignment to silence this warning
┃┃         if ( ret->ctx = calloc(sizeof(MMIOT), 1) ) {
┃┃                       ^
┃┃              (                                  )
┃┃ mkdio.c:28:16: note: use '==' to turn this assignment into an equality comparison
┃┃         if ( ret->ctx = calloc(sizeof(MMIOT), 1) ) {
┃┃                       ^
┃┃                       ==
┃┃ mkdio.c:274:14: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
┃┃     if ( len = S(f.out) ) {
┃┃          ~~~~^~~~~~~~~~
┃┃ mkdio.c:274:14: note: place parentheses around the assignment to silence this warning
┃┃     if ( len = S(f.out) ) {
┃┃              ^
┃┃          (             )
┃┃ mkdio.c:274:14: note: use '==' to turn this assignment into an equality comparison
┃┃     if ( len = S(f.out) ) {
┃┃              ^
┃┃              ==
┃┃ mkdio.c:306:49: warning: comparison of integers of different signs: 'unsigned long' and 'int' [-Wsign-compare]
┃┃         status = fwrite(T(f.out), S(f.out), 1, output) == S(f.out);
┃┃                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~
┃┃ 3 warnings generated.
┃┃ compiling mktags.c
┃┃ mktags.c:20:15: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
┃┃     p->size = strlen(id);
┃┃             ~ ^~~~~~~~~~
┃┃ mktags.c:44:1: warning: type specifier missing, defaults to 'int' [-Wimplicit-int]
┃┃ main()
┃┃ ^
┃┃ mktags.c:51:8: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("STYLE");
┃┃        ^~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:52:8: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("SCRIPT");
┃┃        ^~~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:53:8: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("ADDRESS");
┃┃        ^~~~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:54:8: warning: passing 'const char [4]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("BDO");
┃┃        ^~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:55:8: warning: passing 'const char [11]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("BLOCKQUOTE");
┃┃        ^~~~~~~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:56:8: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("CENTER");
┃┃        ^~~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:57:8: warning: passing 'const char [4]' to paramet
┃┃ er of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("DFN");
┃┃        ^~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:58:8: warning: passing 'const char [4]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("DIV");
┃┃        ^~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:59:8: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("OBJECT");
┃┃        ^~~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:60:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("H1");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:61:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("H2");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:62:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("H3");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:63:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("H4");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:64:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("H5");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:65:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("H6");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:66:8: warning: passing 'const char [8]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("LISTING");
┃┃        ^~~~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(c
┃┃ har *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:67:8: warning: passing 'const char [5]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("NOBR");
┃┃        ^~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:68:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("UL");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:69:8: warning: passing 'const char [2]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("P");
┃┃        ^~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:70:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("OL");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:71:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("DL");
┃┃        ^~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:72:8: warning: passing 'const char [10]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("PLAINTEXT");
┃┃        ^~~~~~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:73:8: warning: passing 'const char [4]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("PRE");
┃┃        ^~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:74:8: warning: passing 'const char [6]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("TABLE");
┃┃        ^~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:75:8: warning: passing 'const char [4]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("WBR");
┃┃        ^~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:76:8: warning: passing 'const char [4]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("XMP");
┃┃        ^~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0
┃┃ )
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:77:8: warning: passing 'const char [3]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     SC("HR");
┃┃        ^~~~
┃┃ mktags.c:49:30: note: expanded from macro 'SC'
┃┃ #define SC(x)   define_one_tag(x, 1)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:78:8: warning: passing 'const char [7]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("IFRAME");
┃┃        ^~~~~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ mktags.c:79:8: warning: passing 'const char [4]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     KW("MAP");
┃┃        ^~~~~
┃┃ mktags.c:48:30: note: expanded from macro 'KW'
┃┃ #define KW(x)   define_one_tag(x, 0)
┃┃                                ^
┃┃ mktags.c:15:22: note: passing argument to parameter 'id' here
┃┃ define_one_tag(char *id, int selfclose)
┃┃                      ^
┃┃ 31 warnings generated.
┃┃ compiling pgm_options.c
┃┃ pgm_options.c:34:7: warning: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "tabstop",       "default (4-space) tabstops", 0, 0, 1, MKD_TABSTOP  },
┃┃       ^~~~~~~~~
┃┃ pgm_options.c:34:24: warning: initializing 'char *' with an expression of type 'const char [27]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "tabstop",       "default (4-space) tabstops", 0, 0, 1, MKD_TABSTOP  },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:35:7: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "image",         "images",                     1, 0, 1, MKD_NOIMAGE  },
┃┃       ^~~~~~~
┃┃ pgm_options.c:35:24: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "image",         "images",                     1, 0, 1, MKD_NOIMAGE  },
┃┃                        ^~~~~~~~
┃┃ pgm_options.c:36:7: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "links",         "links",                      1, 0, 1, MKD_NOLINKS  },
┃┃       ^~~~~~~
┃┃ pgm_options.c:36:24: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "links",         "links",                      1, 0, 1, MKD_NOLINKS  },
┃┃                        ^~~~~~~
┃┃ pgm_options.c:37:7: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "relax",         "emphasis inside words",      1, 1, 1, MKD_STRICT   },
┃┃       ^~~~~~~
┃┃ pgm_options.c:37:24: warning: initializing 'char *' with an expression of type 'const char [22]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "relax",         "emphasis inside words",      1, 1, 1, MKD_STRICT   },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:38:7: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "strict",        "emphasis inside words",      0, 0, 1, MKD_STRICT   },
┃┃       ^~~~~~~~
┃┃ pgm_options.c:38:24: warning: initializing 'char *' with an expression of type 'const char [22]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "strict",     
┃┃    "emphasis inside words",      0, 0, 1, MKD_STRICT   },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:39:7: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "tables",        "tables",                     1, 0, 1, MKD_NOTABLES },
┃┃       ^~~~~~~~
┃┃ pgm_options.c:39:24: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "tables",        "tables",                     1, 0, 1, MKD_NOTABLES },
┃┃                        ^~~~~~~~
┃┃ pgm_options.c:40:7: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "header",        "pandoc-style headers",       1, 0, 1, MKD_NOHEADER },
┃┃       ^~~~~~~~
┃┃ pgm_options.c:40:24: warning: initializing 'char *' with an expression of type 'const char [21]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "header",        "pandoc-style headers",       1, 0, 1, MKD_NOHEADER },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:41:7: warning: initializing 'char *' with an expression of type 'const char [5]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "html",          "raw html",                   1, 0, 1, MKD_NOHTML   },
┃┃       ^~~~~~
┃┃ pgm_options.c:41:24: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "html",          "raw html",                   1, 0, 1, MKD_NOHTML   },
┃┃                        ^~~~~~~~~~
┃┃ pgm_options.c:42:7: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "ext",           "extended protocols",         1, 0, 1, MKD_NO_EXT   },
┃┃       ^~~~~
┃┃ pgm_options.c:42:24: warning: initializing 'char *' with an expression of type 'const char [19]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "ext",           "extended protocols",         1, 0, 1, MKD_NO_EXT   },
┃┃                        ^~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:43:7: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "cdata",         "generate cdata",             0, 0, 0, MKD_CDATA    },
┃┃       ^~~~~~~
┃┃ pgm_options.c:43:24: warning: initializing 'char *' with an expression of type 'const char [15]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "cdata",         "generate cdata",             0, 0, 0, MKD_CDATA    },
┃┃                        ^~~~~~~~~~~~~~~~
┃┃ pgm_options.c:44:7: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "smarty",        "smartypants",                1, 0, 1, MKD_NOPANTS  },
┃┃       ^~~~~~~~
┃┃ pgm_options.c:44:24: warning: initializing 'char *' with an expression of type 'const char [12]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "smarty",        "smartypants",                1, 0, 1, MKD_NOPANTS  },
┃┃                        ^~~~~~~~~~~~~
┃┃ pgm_options.c:45:7: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "pants",         "smartypants",                1, 1, 1, MKD_NOPANTS  },
┃┃       ^~~~~~~
┃┃ pgm_options.c:45:24: warning: initializing 'char *' with an expression of type 'const char [12]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "pants",         "smartypants",                1, 1, 1, MKD_NOPANTS  },
┃┃                        ^~~~~~~~~~~~~
┃┃ pgm_options.c:46:7: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "toc",           "table
┃┃ s of contents",         0, 0, 1, MKD_TOC      },
┃┃       ^~~~~
┃┃ pgm_options.c:46:24: warning: initializing 'char *' with an expression of type 'const char [19]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "toc",           "tables of contents",         0, 0, 1, MKD_TOC      },
┃┃                        ^~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:47:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "autolink",      "autolinking",                0, 0, 1, MKD_AUTOLINK },
┃┃       ^~~~~~~~~~
┃┃ pgm_options.c:47:24: warning: initializing 'char *' with an expression of type 'const char [12]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "autolink",      "autolinking",                0, 0, 1, MKD_AUTOLINK },
┃┃                        ^~~~~~~~~~~~~
┃┃ pgm_options.c:48:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "safelink",      "safe links",                 0, 0, 1, MKD_SAFELINK },
┃┃       ^~~~~~~~~~
┃┃ pgm_options.c:48:24: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "safelink",      "safe links",                 0, 0, 1, MKD_SAFELINK },
┃┃                        ^~~~~~~~~~~~
┃┃ pgm_options.c:49:7: warning: initializing 'char *' with an expression of type 'const char [14]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "strikethrough", "strikethrough",              1, 0, 1, MKD_NOSTRIKETHROUGH },
┃┃       ^~~~~~~~~~~~~~~
┃┃ pgm_options.c:49:24: warning: initializing 'char *' with an expression of type 'const char [14]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "strikethrough", "strikethrough",              1, 0, 1, MKD_NOSTRIKETHROUGH },
┃┃                        ^~~~~~~~~~~~~~~
┃┃ pgm_options.c:50:7: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "del",           "strikethrough",              1, 1, 1, MKD_NOSTRIKETHROUGH },
┃┃       ^~~~~
┃┃ pgm_options.c:50:24: warning: initializing 'char *' with an expression of type 'const char [14]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "del",           "strikethrough",              1, 1, 1, MKD_NOSTRIKETHROUGH },
┃┃                        ^~~~~~~~~~~~~~~
┃┃ pgm_options.c:51:7: warning: initializing 'char *' with an expression of type 'const char [12]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "superscript",   "superscript",                1, 0, 1, MKD_NOSUPERSCRIPT },
┃┃       ^~~~~~~~~~~~~
┃┃ pgm_options.c:51:24: warning: initializing 'char *' with an expression of type 'const char [12]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "superscript",   "superscript",                1, 0, 1, MKD_NOSUPERSCRIPT },
┃┃                        ^~~~~~~~~~~~~
┃┃ pgm_options.c:52:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "emphasis",      "emphasis inside words",      0, 0, 1, MKD_NORELAXED },
┃┃       ^~~~~~~~~~
┃┃ pgm_options.c:52:24: warning: initializing 'char *' with an expression of type 'const char [22]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "emphasis",      "emphasis inside words",      0, 0, 1, MKD_NORELAXED },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:53:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "divquote",      ">%class% blockquotes",       1, 0, 1, MKD_NODIVQUOTE },
┃┃       ^~~~~~~~~~
┃┃ pgm_options.c:53:24: warning: initializing 'char *' with an expression of type 'const char [21]' discards qualifiers [-Wincompatible-pointer-types-discards-qual
┃┃ ifiers]
┃┃     { "divquote",      ">%class% blockquotes",       1, 0, 1, MKD_NODIVQUOTE },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:54:7: warning: initializing 'char *' with an expression of type 'const char [10]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "alphalist",     "alpha lists",                1, 0, 1, MKD_NOALPHALIST },
┃┃       ^~~~~~~~~~~
┃┃ pgm_options.c:54:24: warning: initializing 'char *' with an expression of type 'const char [12]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "alphalist",     "alpha lists",                1, 0, 1, MKD_NOALPHALIST },
┃┃                        ^~~~~~~~~~~~~
┃┃ pgm_options.c:55:7: warning: initializing 'char *' with an expression of type 'const char [15]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "definitionlist","definition lists",           1, 0, 1, MKD_NODLIST },
┃┃       ^~~~~~~~~~~~~~~~
┃┃ pgm_options.c:55:24: warning: initializing 'char *' with an expression of type 'const char [17]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "definitionlist","definition lists",           1, 0, 1, MKD_NODLIST },
┃┃                        ^~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:56:7: warning: initializing 'char *' with an expression of type 'const char [4]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "1.0",           "markdown 1.0 compatibility", 0, 0, 1, MKD_1_COMPAT },
┃┃       ^~~~~
┃┃ pgm_options.c:56:24: warning: initializing 'char *' with an expression of type 'const char [27]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "1.0",           "markdown 1.0 compatibility", 0, 0, 1, MKD_1_COMPAT },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:57:7: warning: initializing 'char *' with an expression of type 'const char [10]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "footnotes",     "markdown extra footnotes",   0, 0, 1, MKD_EXTRA_FOOTNOTE },
┃┃       ^~~~~~~~~~~
┃┃ pgm_options.c:57:24: warning: initializing 'char *' with an expression of type 'const char [25]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "footnotes",     "markdown extra footnotes",   0, 0, 1, MKD_EXTRA_FOOTNOTE },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:58:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "footnote",      "markdown extra footnotes",   0, 1, 1, MKD_EXTRA_FOOTNOTE },
┃┃       ^~~~~~~~~~
┃┃ pgm_options.c:58:24: warning: initializing 'char *' with an expression of type 'const char [25]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "footnote",      "markdown extra footnotes",   0, 1, 1, MKD_EXTRA_FOOTNOTE },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:59:7: warning: initializing 'char *' with an expression of type 'const char [6]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "style",         "extract style blocks",       1, 0, 1, MKD_NOSTYLE },
┃┃       ^~~~~~~
┃┃ pgm_options.c:59:24: warning: initializing 'char *' with an expression of type 'const char [21]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "style",         "extract style blocks",       1, 0, 1, MKD_NOSTYLE },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:60:7: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "dldiscount",    "discount-style definition lists", 1, 0, 1, MKD_NODLDISCOUNT },
┃┃       ^~~~~~~~~~~~
┃┃ pgm_options.c:60:24: warning: initializing 'char *' with an expression of type 'const char [32]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "dldiscount",    "discount-style definition lists", 1, 0, 1, MKD_NODLDISCOUNT },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:61:7: warning: 
┃┃ initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "dlextra",       "extra-style definition lists", 0, 0, 1, MKD_DLEXTRA },
┃┃       ^~~~~~~~~
┃┃ pgm_options.c:61:24: warning: initializing 'char *' with an expression of type 'const char [29]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "dlextra",       "extra-style definition lists", 0, 0, 1, MKD_DLEXTRA },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:62:7: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "fencedcode",    "fenced code blocks",         0, 0, 1, MKD_FENCEDCODE },
┃┃       ^~~~~~~~~~~~
┃┃ pgm_options.c:62:24: warning: initializing 'char *' with an expression of type 'const char [19]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "fencedcode",    "fenced code blocks",         0, 0, 1, MKD_FENCEDCODE },
┃┃                        ^~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:63:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "idanchor",      "id= anchors in TOC",         0, 0, 1, MKD_IDANCHOR },
┃┃       ^~~~~~~~~~
┃┃ pgm_options.c:63:24: warning: initializing 'char *' with an expression of type 'const char [19]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "idanchor",      "id= anchors in TOC",         0, 0, 1, MKD_IDANCHOR },
┃┃                        ^~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:64:7: warning: initializing 'char *' with an expression of type 'const char [11]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "githubtags",    "permit - and _ in element names", 0, 0, 0, MKD_GITHUBTAGS },
┃┃       ^~~~~~~~~~~~
┃┃ pgm_options.c:64:24: warning: initializing 'char *' with an expression of type 'const char [32]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "githubtags",    "permit - and _ in element names", 0, 0, 0, MKD_GITHUBTAGS },
┃┃                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:65:7: warning: initializing 'char *' with an expression of type 'const char [17]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "urlencodedanchor", "urlencode special chars in TOC links", 0, 0, 0, MKD_URLENCODEDANCHOR },
┃┃       ^~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:65:27: warning: initializing 'char *' with an expression of type 'const char [37]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "urlencodedanchor", "urlencode special chars in TOC links", 0, 0, 0, MKD_URLENCODEDANCHOR },
┃┃                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ pgm_options.c:94:14: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
┃┃         for (i=0; i < NR(opts); i++)
┃┃                   ~ ^ ~~~~~~~~
┃┃ pgm_options.c:101:14: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
┃┃         for (i=0; i < NR(opts); i++)
┃┃                   ~ ^ ~~~~~~~~
┃┃ pgm_options.c:129:15: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
┃┃         for ( i=0; i < NR(opts); i++ )
┃┃                    ~ ^ ~~~~~~~~
┃┃ pgm_options.c:133:9: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
┃┃         if ( i < NR(opts) ) {
┃┃              ~ ^ ~~~~~~~~
┃┃ 68 warnings generated.
┃┃ compiling rdiscount.c
┃┃ rdiscount.c:25:7: warning: initializing 'char *' with an expression of type 'const char [12]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "filter_html", MKD_NOHTML },
┃┃       ^~~~~~~~~~~~~
┃┃ rdiscount.c:26:7: warning: initializing 'char *' with an expression of type 'const char [10]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "footnotes", MKD_EXTRA_FOOTNOTE },
┃┃       ^~~~~~~~~~~
┃┃ rdiscount.c:27:7: warning: initi
┃┃ alizing 'char *' with an expression of type 'const char [13]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "generate_toc", MKD_TOC },
┃┃       ^~~~~~~~~~~~~~
┃┃ rdiscount.c:28:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "no_image", MKD_NOIMAGE },
┃┃       ^~~~~~~~~~
┃┃ rdiscount.c:29:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "no_links", MKD_NOLINKS },
┃┃       ^~~~~~~~~~
┃┃ rdiscount.c:30:7: warning: initializing 'char *' with an expression of type 'const char [10]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "no_tables", MKD_NOTABLES },
┃┃       ^~~~~~~~~~~
┃┃ rdiscount.c:31:7: warning: initializing 'char *' with an expression of type 'const char [7]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "strict", MKD_STRICT },
┃┃       ^~~~~~~~
┃┃ rdiscount.c:32:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "autolink", MKD_AUTOLINK },
┃┃       ^~~~~~~~~~
┃┃ rdiscount.c:33:7: warning: initializing 'char *' with an expression of type 'const char [9]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "safelink", MKD_SAFELINK },
┃┃       ^~~~~~~~~~
┃┃ rdiscount.c:34:7: warning: initializing 'char *' with an expression of type 'const char [20]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "no_pseudo_protocols", MKD_NO_EXT },
┃┃       ^~~~~~~~~~~~~~~~~~~~~
┃┃ rdiscount.c:35:7: warning: initializing 'char *' with an expression of type 'const char [15]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "no_superscript", MKD_NOSUPERSCRIPT },
┃┃       ^~~~~~~~~~~~~~~~
┃┃ rdiscount.c:36:7: warning: initializing 'char *' with an expression of type 'const char [17]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
┃┃     { "no_strikethrough", MKD_NOSTRIKETHROUGH },
┃┃       ^~~~~~~~~~~~~~~~~~
┃┃ rdiscount.c:53:17: error: implicit declaration of function 'rb_rdiscount__get_flags' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
┃┃     int flags = rb_rdiscount__get_flags(self);
┃┃                 ^
┃┃ rdiscount.c:66:48: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
┃┃     MMIOT *doc = mkd_string(RSTRING_PTR(text), RSTRING_LEN(text), flags);
┃┃                  ~~~~~~~~~~                    ^~~~~~~~~~~~~~~~~
┃┃ /opt/rubies/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1007:6: note: expanded from macro 'RSTRING_LEN'
┃┃      RSTRING_EMBED_LEN(str) : \
┃┃      ^~~~~~~~~~~~~~~~~~~~~~
┃┃ /opt/rubies/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1003:6: note: expanded from macro 'RSTRING_EMBED_LEN'
┃┃      (long)((RBASIC(str)->flags >> RSTRING_EMBED_LEN_SHIFT) & \
┃┃      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ rdiscount.c:66:48: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
┃┃     MMIOT *doc = mkd_string(RSTRING_PTR(text), RSTRING_LEN(text), flags);
┃┃                  ~~~~~~~~~~                    ^~~~~~~~~~~~~~~~~
┃┃ /opt/rubies/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1008:28: note: expanded from macro 'RSTRING_LEN'
┃┃      RSTRING(str)->as.heap.len)
┃┃      ~~~~~~~~~~~~~~~~~~~~~~^~~
┃┃ rdiscount.c:96:17: error: implicit declaration of function 'rb_rdiscount__get_flags' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
┃┃     int flags = rb_rdiscount__get_flags(self);
┃┃                 ^
┃┃ rdiscount.c:105:48: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
┃┃     MMIOT *doc = mkd_string(RSTRING_PTR(text), RSTRING_LEN(text), flags);
┃┃                  ~~~~~~~~~~                    ^~~~~~~~~~~~~~~~~
┃┃ /opt/rubies/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1007:6: note: expanded from macro 'RSTRING_LEN'
┃┃      RSTRING_EMBED_LEN(str) : \
┃┃      ^~~~~~~~~~~~~~~~~~~~~~
┃┃ /opt/rubies/2.7.2/include/ruby-2.7.0/ruby/
┃┃ ruby.h:1003:6: note: expanded from macro 'RSTRING_EMBED_LEN'
┃┃      (long)((RBASIC(str)->flags >> RSTRING_EMBED_LEN_SHIFT) & \
┃┃      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
┃┃ rdiscount.c:105:48: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
┃┃     MMIOT *doc = mkd_string(RSTRING_PTR(text), RSTRING_LEN(text), flags);
┃┃                  ~~~~~~~~~~                    ^~~~~~~~~~~~~~~~~
┃┃ /opt/rubies/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1008:28: note: expanded from macro 'RSTRING_LEN'
┃┃      RSTRING(str)->as.heap.len)
┃┃      ~~~~~~~~~~~~~~~~~~~~~~^~~
┃┃ 16 warnings and 2 errors generated.
┃┃ make: *** [rdiscount.o] Error 1
┃┃ make failed, exit code 2
┃┃ Gem files will remain installed in /Users/plentz/.gem/ruby/2.7.2/gems/rdiscount-2.2.0.1 for inspection.
┃┃ Results logged to /Users/plentz/.gem/ruby/2.7.2/extensions/x86_64-darwin-19/2.7.0-static/rdiscount-2.2.0.1/gem_make.out
┃┃ An error occurred while installing rdiscount (2.2.0.1), and Bundler cannot continue.
┃┃ Make sure that `gem install rdiscount -v '2.2.0.1' --source 'https://rubygems.org/'` succeeds before bundling.
┃┃ In Gemfile:
┃┃   ronn was resolved to 0.7.3, which depends on
┃┃     rdiscount
┃┣━━ bundle install failed ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃┃ bundler failed. This generally indicates a problem with your project's Gemfile.
┃┃ 
┃┃ * Was it a gem specified as a github source, with a SHA that has been rebased away?
┃┃   => Update the gem or contact the author and try to have them restore the branch
┃┃ 
┃┃ * Was it a native extension that failed to compile?
┃┃   => Maybe it's an incompatibility with the most recent XCode. Check for a new version of the gem.
┃┃   => Is it happening for anyone else? Ask your teammates.
┃┃ 
┃┃ * Something else?
┃┃   => Pick out a piece of the error shown above and Google it, often others have experienced the issue
┃┃   => Ask in your project's slack room, maybe #developers-talk
┃┃ 
┃┃ Docs on bundle install can be found here: https://bundler.io/man/bundle-install.1.html
┃┗━━ bundle install Failed! ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (38.2s) ━━
┃ ✗ Error Reason:
┗━━ 💥  Failed! Aborting! ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (42.36s) ━━

💥  bundle install: failed!

```
</details>

It successfully installs after this changes.