### PR TITLE
Introduce schema version 2, including a secure per-secret identifier

### DIFF
--- a/cmd/ejson/actions.go
+++ b/cmd/ejson/actions.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Shopify/ejson"
+	"github.com/Shopify/ejson/crypto"
 )
 
 func encryptAction(args []string) error {
@@ -60,6 +61,15 @@ func keygenAction(args []string, keydir string, wFlag bool) error {
 	} else {
 		fmt.Printf("Public Key:\n%s\nPrivate Key:\n%s\n", pub, priv)
 	}
+	return nil
+}
+
+func secretIdentityAction(secret string) error {
+	identity, err := crypto.SecretIdentity([]byte(secret))
+	if err != nil {
+		return err
+	}
+	fmt.Println(fmt.Sprintf("%x", identity))
 	return nil
 }
 

--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -29,7 +29,7 @@ func main() {
 
 			if cmd, ok := data.(cli.Command); ok {
 				switch cmd.Name {
-				case "encrypt", "decrypt", "keygen":
+				case "encrypt", "decrypt", "keygen", "identify":
 					execManpage("1", "ejson-"+cmd.Name)
 				}
 			}
@@ -105,6 +105,34 @@ func main() {
 			Action: func(c *cli.Context) {
 				if err := keygenAction(c.Args(), c.GlobalString("keydir"), c.Bool("write")); err != nil {
 					fmt.Fprintln(os.Stderr, "Key generation failed:", err)
+					os.Exit(1)
+				}
+			},
+		},
+		{
+			Name:      "identify",
+			ShortName: "i",
+			Usage:     "display the given secrets identity string",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "secret",
+					Usage: "read the secret from command line argument, not from STDIN",
+				},
+			},
+			Action: func(c *cli.Context) {
+				secretToIdentify := ""
+				if c.String("secret") != "" {
+					secretToIdentify = c.String("secret")
+				} else {
+					stdinContent, err := ioutil.ReadAll(os.Stdin)
+					if err != nil {
+						fmt.Fprintln(os.Stderr, "Failed to read from stdin:", err)
+						os.Exit(1)
+					}
+					secretToIdentify = strings.TrimSpace(string(stdinContent))
+				}
+				if err := secretIdentityAction(secretToIdentify); err != nil {
+					fmt.Fprintln(os.Stderr, "Secret identity generation failed:", err)
 					os.Exit(1)
 				}
 			},

--- a/crypto/boxed_message.go
+++ b/crypto/boxed_message.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-var messageParser = regexp.MustCompile("\\AEJ\\[(\\d):([A-Za-z0-9+=/]{44}):([A-Za-z0-9+=/]{32}):([A-Za-z0-9+=/]+):?([A-Za-z0-9]{128})?\\]\\z")
+var messageParser = regexp.MustCompile("\\AEJ\\[(\\d):([A-Za-z0-9+=/]{44}):([A-Za-z0-9+=/]{32}):([A-Za-z0-9+=/]+):?([A-Za-z0-9]{64})?\\]\\z")
 
 // boxedMessage dumps and loads the wire format for encrypted messages. The
 // schema is fairly simple:

--- a/crypto/boxed_message_test.go
+++ b/crypto/boxed_message_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"crypto/sha512"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -34,6 +35,37 @@ func TestBoxedMessageRoundtripping(t *testing.T) {
 			So(IsBoxedMessage([]byte("nope")), ShouldBeFalse)
 			So(IsBoxedMessage([]byte("EJ[]")), ShouldBeFalse)
 			So(IsBoxedMessage([]byte("EJ[1:12345678901234567890123456789012345678901234:12345678901234567890123456789012:a]")), ShouldBeTrue) // we could be stricter than this.
+			So(IsBoxedMessage([]byte("EJ[2:12345678901234567890123456789012345678901234:12345678901234567890123456789012:a:162b0b32f02482d5aca0a7c93dd03ceac3acd7e410a5f18f3fb990fc958ae0df6f32233b91831eaf99ca581a8c4ddf9c8ba315ac482db6d4ea01cc7884a635be]")), ShouldBeTrue)
+		})
+	})
+}
+
+func TestBoxedMessageSchemaVersion2(t *testing.T) {
+	Convey("BoxedMessage", t, func() {
+		pk := [32]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+		nonce := [24]byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+		wire := "EJ[2:AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=:AgICAgICAgICAgICAgICAgICAgICAgIC:YQ==:1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75]"
+		hash := sha512.New()
+		hash.Write([]byte("a"))
+		hashSum := hash.Sum(nil)
+
+		Convey("Load", func() {
+			bm := boxedMessage{}
+			err := bm.Load([]byte(wire))
+			So(err, ShouldBeNil)
+			So(bm.EncrypterPublic, ShouldResemble, pk)
+			So(bm.Nonce, ShouldResemble, nonce)
+			So(bm.Box, ShouldResemble, []byte("a"))
+		})
+		Convey("Dump", func() {
+			bm := boxedMessage{
+				SchemaVersion:   2,
+				EncrypterPublic: pk,
+				Nonce:           nonce,
+				Box:             []byte("a"),
+				Identity:        hashSum,
+			}
+			So(string(bm.Dump()), ShouldEqual, wire)
 		})
 	})
 }

--- a/crypto/boxed_message_test.go
+++ b/crypto/boxed_message_test.go
@@ -1,7 +1,6 @@
 package crypto
 
 import (
-	"crypto/sha512"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -35,7 +34,7 @@ func TestBoxedMessageRoundtripping(t *testing.T) {
 			So(IsBoxedMessage([]byte("nope")), ShouldBeFalse)
 			So(IsBoxedMessage([]byte("EJ[]")), ShouldBeFalse)
 			So(IsBoxedMessage([]byte("EJ[1:12345678901234567890123456789012345678901234:12345678901234567890123456789012:a]")), ShouldBeTrue) // we could be stricter than this.
-			So(IsBoxedMessage([]byte("EJ[2:12345678901234567890123456789012345678901234:12345678901234567890123456789012:a:162b0b32f02482d5aca0a7c93dd03ceac3acd7e410a5f18f3fb990fc958ae0df6f32233b91831eaf99ca581a8c4ddf9c8ba315ac482db6d4ea01cc7884a635be]")), ShouldBeTrue)
+			So(IsBoxedMessage([]byte("EJ[2:12345678901234567890123456789012345678901234:12345678901234567890123456789012:a:e14a700d884f652544e3b3af689010e98be66a855bc6cd2624ff7df4a3f098a8]")), ShouldBeTrue)
 		})
 	})
 }
@@ -44,10 +43,8 @@ func TestBoxedMessageSchemaVersion2(t *testing.T) {
 	Convey("BoxedMessage", t, func() {
 		pk := [32]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
 		nonce := [24]byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
-		wire := "EJ[2:AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=:AgICAgICAgICAgICAgICAgICAgICAgIC:YQ==:1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75]"
-		hash := sha512.New()
-		hash.Write([]byte("a"))
-		hashSum := hash.Sum(nil)
+		identity := []byte{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3}
+		wire := "EJ[2:AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=:AgICAgICAgICAgICAgICAgICAgICAgIC:YQ==:0303030303030303030303030303030303030303030303030303030303030303]"
 
 		Convey("Load", func() {
 			bm := boxedMessage{}
@@ -63,7 +60,7 @@ func TestBoxedMessageSchemaVersion2(t *testing.T) {
 				EncrypterPublic: pk,
 				Nonce:           nonce,
 				Box:             []byte("a"),
-				Identity:        hashSum,
+				Identity:        identity,
 			}
 			So(string(bm.Dump()), ShouldEqual, wire)
 		})

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -12,11 +12,11 @@ package crypto
 
 import (
 	"crypto/rand"
-	"crypto/sha512"
 	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/nacl/box"
+	"golang.org/x/crypto/scrypt"
 )
 
 // Keypair models a Curve25519 keypair. To generate a new Keypair, declare an
@@ -102,9 +102,11 @@ func (e *Encrypter) encrypt(message []byte) (*boxedMessage, error) {
 		return nil, err
 	}
 
-	hash := sha512.New()
-	hash.Write(message)
-	identity := hash.Sum(nil)
+	identity, err := scrypt.Key(message, []byte("ejson"), 1<<15, 8, 1, 32)
+	if err != nil {
+		return nil, err
+	}
+
 	out := box.SealAfterPrecomputation(nil, []byte(message), &nonce, &e.SharedKey)
 
 	return &boxedMessage{

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -12,6 +12,7 @@ package crypto
 
 import (
 	"crypto/rand"
+	"crypto/sha512"
 	"errors"
 	"fmt"
 
@@ -101,13 +102,17 @@ func (e *Encrypter) encrypt(message []byte) (*boxedMessage, error) {
 		return nil, err
 	}
 
+	hash := sha512.New()
+	hash.Write(message)
+	identity := hash.Sum(nil)
 	out := box.SealAfterPrecomputation(nil, []byte(message), &nonce, &e.SharedKey)
 
 	return &boxedMessage{
-		SchemaVersion:   1,
+		SchemaVersion:   2,
 		EncrypterPublic: e.Keypair.Public,
 		Nonce:           nonce,
 		Box:             out,
+		Identity:        identity,
 	}, nil
 }
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -102,7 +102,7 @@ func (e *Encrypter) encrypt(message []byte) (*boxedMessage, error) {
 		return nil, err
 	}
 
-	identity, err := scrypt.Key(message, []byte("ejson"), 1<<15, 8, 1, 32)
+	identity, err := SecretIdentity(message)
 	if err != nil {
 		return nil, err
 	}
@@ -164,4 +164,8 @@ func genNonce() (nonce [24]byte, err error) {
 		err = fmt.Errorf("not enough bytes returned from rand.Reader")
 	}
 	return
+}
+
+func SecretIdentity(message []byte) ([]byte, error) {
+	return scrypt.Key(message, []byte("ejson"), 1<<15, 8, 1, 32)
 }

--- a/man/man1/ejson-decrypt.1.ronn
+++ b/man/man1/ejson-decrypt.1.ronn
@@ -21,4 +21,4 @@ be present in the keydir. See ejson(1) for instructions on changing the keydir.
 
 ## SEE ALSO
 
-ejson(1) ejson(5) ejson-encrypt(1) ejson-keygen(1)
+ejson(1) ejson(5) ejson-encrypt(1) ejson-keygen(1) ejson-identify(1)

--- a/man/man1/ejson-encrypt.1.ronn
+++ b/man/man1/ejson-encrypt.1.ronn
@@ -12,4 +12,4 @@ encrypted and the files will be overwritten in place.
 
 ## SEE ALSO
 
-ejson(1) ejson(5) ejson-decrypt(1) ejson-keygen(1)
+ejson(1) ejson(5) ejson-decrypt(1) ejson-keygen(1) ejson-identify(1)

--- a/man/man1/ejson-keygen.1.ronn
+++ b/man/man1/ejson-keygen.1.ronn
@@ -21,4 +21,4 @@ decrypting system(s).
 
 ## SEE ALSO
 
-ejson(1) ejson(5) ejson-encrypt(1) ejson-decrypt(1)
+ejson(1) ejson(5) ejson-encrypt(1) ejson-decrypt(1) ejson-identify(1)

--- a/man/man1/ejson.1.ronn
+++ b/man/man1/ejson.1.ronn
@@ -33,6 +33,9 @@ workflow example.
   * `ejson keygen` ejson-keygen(1):
     Generate an ejson keypair (alias: `ejson g`)
 
+  * `ejson identify` ejson-identify(1):
+    Display the ejson identification string for a given secret (alias: `ejson i`)
+
 ## WORKFLOW
 
 ### 1: Create the Keydir

--- a/man/man5/ejson.5.ronn
+++ b/man/man5/ejson.5.ronn
@@ -53,10 +53,10 @@ example, the password in this excerpt `will` be encrypted.
 ## SECRET SCHEMA
 
 When a value is encrypted, it will be replaced by a relatively long string of
-the form `"EJ[V:P:N:M]"`. The fields are:
+the form `"EJ[V:P:N:M:I]"`. The fields are:
 
   * `V` (decimal-as-string int):
-    Schema Version, hard-coded to "1" for now
+    Schema Version, currently uses "2", previously it was hard-coded to "1"
 
   * `P` (base64-encoded 32-byte array):
     Public key of an ephemeral keypair used to encrypt this key
@@ -67,6 +67,9 @@ the form `"EJ[V:P:N:M]"`. The fields are:
   * `M` (base64-encoded variable-length array):
     Raw ciphertext
 
+  * `I` (hex-encoded 32-byte array):
+    Secret identification string
+
 ## SEE ALSO
 
-ejson(1) ejson-encrypt(1) ejson-decrypt(1) ejson-keygen(1)
+ejson(1) ejson-encrypt(1) ejson-decrypt(1) ejson-keygen(1) ejson-indentify(1)


### PR DESCRIPTION
## Rationale 
With an ever growing collection of ejson documents across multiple repositories, managed by various teams, the burden to manage recurring (i.e. same secret in more than one file) seems to outweigh the benefits of having individual and completely unrelated cipher texts per encryption operation.

### Example
Given an existing ejson document
```
[19:42:00] 🛒😺 :ejson$ cat /tmp/test.ejson
{
  "_public_key": "3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a",
  "database_password": "very secret do not share",
  "otherbase_password": "very secret do not share"
}
[19:42:11] 🛒😺 :ejson$ ejson encrypt /tmp/test.ejson
Wrote 423 bytes to /tmp/test.ejson.
[19:42:18] 🛒😺 :ejson$ cat /tmp/test.ejson
{
  "_public_key": "3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a",
  "database_password": "EJ[1:tyW3qutcFC8r3EROjkdzfKGM9Z4lFsoO7mqOmUmVBQ4=:8T+lgFLPLy/r/foSEIUjRdLFwIQlpmgU:KhHVzQAr0DnGdLBkGNlYTXr4Q5lWwIbPp8bmnDSLLN+ehAEUih7nfA==]",
  "otherbase_password": "EJ[1:tyW3qutcFC8r3EROjkdzfKGM9Z4lFsoO7mqOmUmVBQ4=:blyGcE6OYv0hyFdRP8rY+QL3ibg1NFY0:bIgQWhFVyA3mZfAYuVemCHPzXdqrzrzIim5rP0HWEp3wgEc/NtvlaA==]"
}
```
if we would be asked to rotate the `database_password`, because there is the suspicion of it having leaked or due to other policies or requirements, there is currently no way (for anyone without access to the private key) to notice that the very same secret is also used for `otherbase_password`. This can get especially tiresome if those two secrets are not within the same file, but in different files across a system landscape.

With the proposed new field added to the cipher text wire format, it becomes trivial to check for duplicate secret usage.
```
[19:49:58] 🛒😺 :ejson$ cat /tmp/test.ejson
{
  "_public_key": "3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a",
  "database_password": "very secret do not share",
  "otherbase_password": "very secret do not share"
}
[14:14:36] 🛒😺 :ejson$ ./build/bin/darwin-amd64 encrypt /tmp/test.ejson
Wrote 553 bytes to /tmp/test.ejson.
[14:14:38] 🛒😺 :ejson$ cat /tmp/test.ejson
{
  "_public_key": "3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a",
  "database_password": "EJ[2:jDxAEbb/hETVyTEd8UUQiEu1vyITDV0aZWhkpGcn+F4=:SYT5e65wzsGnOohswWAxMoXRzt2msszS:a5jP3gJhxEoFul2Fq0lqHYa89zk4E9zlHMAxL8fKC6YbP3ZAvqa8vQ==:2e6e6c65a58c79e86eb45f6b89ca31e2e52674faa451d73d1aa7dc20210cf616]",
  "otherbase_password": "EJ[2:jDxAEbb/hETVyTEd8UUQiEu1vyITDV0aZWhkpGcn+F4=:OYle5PUztAEas4xtwH705dgSqL3w1hnx:mK6YfjPeQ8FW9y+JsDsMYLS9SOjiKTrIBxYy0EX3uleteTe4YoUHKA==:2e6e6c65a58c79e86eb45f6b89ca31e2e52674faa451d73d1aa7dc20210cf616]"
}
```
Instead of the context dependent and vague "please rotate the `database_password`!", this allows very clear instructions, such as 
> replace every secret identified by `2e6e6c65a58c79e86eb45f6b89ca31e2e52674faa451d73d1aa7dc20210cf616` with the new database password.

This opens possibilities for a centralised entity to grep for a known bad identifier across a collection of ejson documents and mass-open change requests to affected users, without having access to the respective private keys.

## Notes and assumptions about security implications of this change

The new identity field uses one of the strongest, widely adapted cryptographic hash functions - scrypt. Reasons this was chosen:
* Available across most major programming languages and tools, more so than SAH512-256, SHA3 or more novel functions.
* Arguably "stronger" than plain usage of the SHA families, being designed for hashing password
* Proven performance with tuneable cost factor - set to `2**15` in this application

Still, it introduces an additional representation of the plain text value, and gives attackers the freedom to chose to either attack the hash sum or the existing NaCl box. 

I was unable to find a reasonable comparison of overall cryptographic strength between the two operations - mostly because they serve to very different applications. To my understanding both can be considered state of the art today.

#### Note
Documentation for scrypt implementations urge the user to chose ["a good random salt"](https://pkg.go.dev/golang.org/x/crypto/scrypt). For our use case, we cannot add a per-secret salt to the hash, as this would defeat the purpose of having it uniquely identifiable across multiple files.

## Implications for existing usages of ejson
The change of the wire format is introduced in a backwards compatible way. Ejson will be able to decrypt both schema version 1 and schema version 2 encrypted documents. It will output schema version 2 documents, including the new field per default.

**I'd like to discuss if this an acceptable way forward, or if we should introduce an additional command line argument that can toggle between the old and the new behaviour for example.**
I do realise that this change might not be favourable to all users, as many will have different requirements for their secrets storage solution.
There is some more work to be done within the included documentation that is dependent on the outcome of above discussion.

