### PR TITLE
Remove Codecov from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,3 @@ script:
   - go mod download
   - go test -race -coverprofile=coverage.txt -covermode=atomic
   
-after_success:
-  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR removes Codecov from Travis-CI as its use is deprecated.