### PR TITLE
Add support for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ binaries: \
 	build/bin/linux-amd64 \
 	build/bin/linux-arm64 \
 	build/bin/darwin-amd64 \
+	build/bin/darwin-arm64 \
 	build/bin/freebsd-amd64 \
 	build/bin/windows-amd64.exe
 gem: $(GEM)
@@ -38,6 +39,8 @@ build/bin/linux-arm64: $(GOFILES) cmd/$(NAME)/version.go
 	GOOS=linux GOARCH=arm64 go build -o "$@" "$(PACKAGE)/cmd/$(NAME)"
 build/bin/darwin-amd64: $(GOFILES) cmd/$(NAME)/version.go
 	GOOS=darwin GOARCH=amd64 go build -o "$@" "$(PACKAGE)/cmd/$(NAME)"
+build/bin/darwin-arm64: $(GOFILES) cmd/$(NAME)/version.go
+	GOOS=darwin GOARCH=arm64 go build -o "$@" "$(PACKAGE)/cmd/$(NAME)"
 build/bin/freebsd-amd64: $(GOFILES) cmd/$(NAME)/version.go
 	GOOS=freebsd GOARCH=amd64 go build -o "$@" "$(PACKAGE)/cmd/$(NAME)"
 build/bin/windows-amd64.exe: $(GOFILES) cmd/$(NAME)/version.go
@@ -53,6 +56,7 @@ rubygem/$(NAME)-$(VERSION).gem: \
 	rubygem/build/linux-amd64/ejson \
 	rubygem/LICENSE.txt \
 	rubygem/build/darwin-amd64/ejson \
+	rubygem/build/darwin-arm64/ejson \
 	rubygem/build/freebsd-amd64/ejson \
 	rubygem/build/windows-amd64/ejson.exe \
 	rubygem/man
@@ -65,6 +69,10 @@ rubygem/man: man
 	cp -a build/man $@
 
 rubygem/build/darwin-amd64/ejson: build/bin/darwin-amd64
+	mkdir -p $(@D)
+	cp -a "$<" "$@"
+
+rubygem/build/darwin-arm64/ejson: build/bin/darwin-arm64
 	mkdir -p $(@D)
 	cp -a "$<" "$@"
 

--- a/rubygem/bin/ejson
+++ b/rubygem/bin/ejson
@@ -2,9 +2,10 @@
 platform = `uname -sm`
 
 dir = case platform
-      when /^Darwin/      ; "darwin-amd64"
-      when /^Linux.*64/   ; "linux-amd64"
-      when /^FreeBSD.*64/ ; "freebsd-amd64"
+      when /^Darwin\sarm64/      ; "darwin-arm64"
+      when /^Darwin/             ; "darwin-amd64"
+      when /^Linux.*64/          ; "linux-amd64"
+      when /^FreeBSD.*64/        ; "freebsd-amd64"
       else
         abort "Ejson is not supported on your platform."
       end


### PR DESCRIPTION
I tried to run ejson in a M1 laptop, and it throws a segmentation fault issue because the vendored binary is not compatible for `arm64`. This PR extends the scripts that build the binaries to include a binary for arm64, and adjusts the Gem's executable, to use the `arm64` binary when running ejson in a Darwin M1 host.