### PR TITLE
actions: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Extract release changelog
+        run: |
+          version=${GITHUB_REF#refs/tags/v*}
+          mkdir -p tmp
+          sed '/^# '$version'/,/^# /!d;//d;/^\s*$/d' CHANGELOG.md > tmp/release_changelog.md
+      - name: Release
+        uses: goreleaser/goreleaser-action@5df302e5e9e4c66310a6b6493a8865b12c555af2
+        with:
+          distribution: goreleaser
+          version: v1.2.1
+          args: release --rm-dist --release-notes=tmp/release_changelog.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Build and upload release artifacts from GitHub Actions, using the existing goreleaser configuration.

Having an automated release process transfers the trust from the uploading developer to GitHub's infrastructure. It is a requirements for [SLSA level 1](https://slsa.dev/spec/v0.1/levels).


# Related
- Closes https://github.com/Shopify/ejson/issues/92
- Related https://github.com/Shopify/ejson/issues/68 (via https://goreleaser.com/customization/sign/ )