### PR TITLE
Collapse newlines in string literals:

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -5,7 +5,7 @@ up:
     - gnu-tar
   - ruby: 3.0.3
   - go:
-      version: 1.18
+      version: '1.20'
   - bundler
 
 commands:

--- a/ejson.go
+++ b/ejson.go
@@ -43,6 +43,11 @@ func Encrypt(in io.Reader, out io.Writer) (int, error) {
 		return -1, err
 	}
 
+	data, err = json.CollapseMultilineStringLiterals(data)
+	if err != nil {
+		return -1, err
+	}
+
 	pubkey, err := json.ExtractPublicKey(data)
 	if err != nil {
 		return -1, err

--- a/ejson_test.go
+++ b/ejson_test.go
@@ -69,7 +69,7 @@ func TestEncryptFileInPlace(t *testing.T) {
 			_, err := EncryptFileInPlace(tempFileName)
 			Convey("should fail", func() {
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "invalid character")
+				So(err.Error(), ShouldContainSubstring, "invalid json")
 			})
 		})
 
@@ -91,6 +91,19 @@ func TestEncryptFileInPlace(t *testing.T) {
 			Convey("should encrypt the file", func() {
 				So(err, ShouldBeNil)
 				match := regexp.MustCompile(`{"_public_key": "8d8.*", "a": "EJ.*"}`)
+				So(match.Find(output), ShouldNotBeNil)
+			})
+		})
+
+		Convey("called with a valid keypair and multiline string", func() {
+			setData(tempFileName, []byte(`{"_public_key": "`+validPubKey+"\", \"a\": \"b\nc\"\n}"))
+
+			_, err := EncryptFileInPlace(tempFileName)
+			output, err := ioutil.ReadFile(tempFileName)
+			So(err, ShouldBeNil)
+			Convey("should encrypt the file", func() {
+				So(err, ShouldBeNil)
+				match := regexp.MustCompile(`{"_public_key": "8d8.*", "a": "EJ.*"`+"\n}")
 				So(match.Find(output), ShouldNotBeNil)
 			})
 		})

--- a/json/walker.go
+++ b/json/walker.go
@@ -51,7 +51,10 @@ func CollapseMultilineStringLiterals(data []byte) ([]byte, error) {
 		if inString && c == '\n' {
 			buf = append(buf, []byte{'\\', 'n'}...)
 			continue
-		}
+    } else if inString && c == '\r' {
+			buf = append(buf, []byte{'\\', 'r'}...)
+			continue
+    }
 		buf = append(buf, c)
 		switch v := scanner.Step(&scanner, int(c)); v {
 		case json.ScanContinue:

--- a/json/walker_test.go
+++ b/json/walker_test.go
@@ -12,9 +12,17 @@ func TestWalker(t *testing.T) {
 	}
 
 	Convey("Walker passes the provided test-cases", t, func() {
-		for _, tc := range testCases {
+		for _, tc := range walkTestCases {
 			walker := Walker{Action: action}
 			act, err := walker.Walk([]byte(tc.in))
+			So(err, ShouldBeNil)
+			So(string(act), ShouldEqual, tc.out)
+		}
+	})
+
+	Convey("CollapseMultilineStringLiterals passes the provided test-cases", t, func() {
+		for _, tc := range collapseTestCases {
+			act, err := CollapseMultilineStringLiterals([]byte(tc.in))
 			So(err, ShouldBeNil)
 			So(string(act), ShouldEqual, tc.out)
 		}
@@ -26,7 +34,7 @@ type testCase struct {
 }
 
 // "E" means encrypted.
-var testCases = []testCase{
+var walkTestCases = []testCase{
 	{`{"a": "b"}`, `{"a": "E"}`},                     // encryption
 	{`{"a" : "b"}`, `{"a" : "E"}`},                   // weird spacing
 	{` {  "a"  :"b" } `, ` {  "a"  :"E" } `},         // trailing spaces
@@ -40,4 +48,11 @@ var testCases = []testCase{
 	{`{"a": {"b": "c"}}`, `{"a": {"b": "E"}}`},       // nesting
 	{`{"a": {"_b": "c"}}`, `{"a": {"_b": "c"}}`},     // nested comment
 	{`{"_a": {"b": "c"}}`, `{"_a": {"b": "E"}}`},     // comments don't inherit
+}
+
+var collapseTestCases = []testCase{
+	{
+		"{\"a\": \"b\nc\nd\"\n}", 
+		"{\"a\": \"b\\nc\\nd\"\n}",
+	},
 }

--- a/json/walker_test.go
+++ b/json/walker_test.go
@@ -52,7 +52,7 @@ var walkTestCases = []testCase{
 
 var collapseTestCases = []testCase{
 	{
-		"{\"a\": \"b\nc\nd\"\n}", 
-		"{\"a\": \"b\\nc\\nd\"\n}",
+		"{\"a\": \"b\r\nc\nd\"\r\n}", 
+		"{\"a\": \"b\\r\\nc\\nd\"\r\n}",
 	},
 }

--- a/man/man5/ejson.5.ronn
+++ b/man/man5/ejson.5.ronn
@@ -50,6 +50,10 @@ example, the password in this excerpt `will` be encrypted.
 }
 ```
 
+For convenience, JSON strings to be encrypted are allowed to contain embedded
+newline characters. These will be translated to escaped newlines. This is often
+useful when encrypting multi-line secrets such as PEM-encoded certificates.
+
 ## SECRET SCHEMA
 
 When a value is encrypted, it will be replaced by a relatively long string of


### PR DESCRIPTION
A common use-case is to want to paste in multiline certificates, etc.

This does a first pass on encrypt in order to first collapse multiline strings into valid JSON, before continuing with handling.