### PR TITLE
ci: update goreleaser to v1.18.1 to release assets for darwin/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: goreleaser/goreleaser-action@5df302e5e9e4c66310a6b6493a8865b12c555af2
         with:
           distribution: goreleaser
-          version: v1.2.1
-          args: release --rm-dist --release-notes=tmp/release_changelog.md
+          version: v1.18.1
+          args: release --clean --release-notes=tmp/release_changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- https://github.com/Shopify/ejson/issues/129

goreleaser was old (v1.2.1) so it failed to release an asset for darwin/arm64

https://github.com/Shopify/ejson/actions/runs/4872615287/jobs/8691044230#step:6:30

```
         • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
```

To fix the issue, I update goreleaser to the latest version v1.18.1. Then I've confirmed the issue has been solved.

```console
$ goreleaser --version
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    1.18.1
GitCommit:     aaa9da33d5e72a0db4c1c815dc746249b78266d2
GitTreeState:  false
BuildDate:     2023-05-05T04:26:12Z
BuiltBy:       goreleaser
GoVersion:     go1.20.4
Compiler:      gc
ModuleSum:     h1:QEpUnMFhSgtqaJbmy9/++KbFNBlITYVIiVYVcz0XaDo=
Platform:      darwin/arm64

$ goreleaser release --snapshot --clean
  • starting release...
  • loading config file                              file=.goreleaser.yaml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=30ca14f25cc3af7aadf4300028977aa9a018b34a latest tag=v1.4.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=1.4.0-SNAPSHOT-30ca14f
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/ejson_windows_386/ejson.exe
    • building                                       binary=dist/ejson_windows_amd64_v1/ejson.exe
    • building                                       binary=dist/ejson_linux_386/ejson
    • building                                       binary=dist/ejson_darwin_arm64/ejson
    • building                                       binary=dist/ejson_linux_arm64/ejson
    • building                                       binary=dist/ejson_darwin_amd64_v1/ejson
    • building                                       binary=dist/ejson_windows_arm64/ejson.exe
    • building                                       binary=dist/ejson_linux_amd64_v1/ejson
    • took: 1s
  • archives
    • creating                                       archive=dist/ejson_1.4.0-SNAPSHOT-30ca14f_windows_amd64.tar.gz
    • creating                                       archive=dist/ejson_1.4.0-SNAPSHOT-30ca14f_windows_arm64.tar.gz
    • creating                                       archive=dist/ejson_1.4.0-SNAPSHOT-30ca14f_linux_amd64.tar.gz
    • creating                                       archive=dist/ejson_1.4.0-SNAPSHOT-30ca14f_linux_386.tar.gz
    • creating                                       archive=dist/ejson_1.4.0-SNAPSHOT-30ca14f_linux_arm64.tar.gz
    • creating                                       archive=dist/ejson_1.4.0-SNAPSHOT-30ca14f_windows_386.tar.gz
    • creating                                       archive=dist/ejson_1.4.0-SNAPSHOT-30ca14f_darwin_arm64.tar.gz
    • creating                                       archive=dist/ejson_1.4.0-SNAPSHOT-30ca14f_darwin_amd64.tar.gz
    • took: 1s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 2s
  • thanks for using goreleaser!
```

The warning was disappeared and an asset for darwin_arm64 was built successfully.