### PR TITLE
dependabot: github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 100
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 100


### PR DESCRIPTION
I did bundler too - https://github.com/Shopify/ejson/commit/2d2a849ccafff153829c6dfd3438215b2bae2172

That was how I realized there was no branch protection 🤦 