### PR TITLE
release: attest tarball provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   packages: write
   id-token: write
+  attestations: write
 
 jobs:
   release:


### PR DESCRIPTION
This is what I came up with https://github.com/thepwagner-org/actions/blob/main/.github/workflows/golang-release-attest.yaml

Since GitHub packages the attestation tool as an actions step, it can't run as a post-build hook in goreleaser like `cosign ...` could.

Luckily GoReleaser leaves the artifacts it generates sitting around in `dist/`, so we can just sign them after the release action has completed!


# Related

- Closes https://github.com/Shopify/ejson/issues/68