### PR TITLE
rm unused import

### DIFF
--- a/cmd/ejson/main.go
+++ b/cmd/ejson/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/urfave/cli"
 )


### PR DESCRIPTION
I caused this in https://github.com/Shopify/ejson/pull/88

I incorrectly assumed this repository had a CI process.
It does, but it didn't when that PR was opened :facepalm:.

