### PR TITLE
goreleaser: embed VERSION

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,9 +1,16 @@
-# .goreleaser.yaml
 builds:
-- main: ./cmd/ejson/
-  flags:
-  - -trimpath
-  ldflags:
-  - -s -w -extldflags "-static"
-  env:
-  - CGO_ENABLED=0
+  - main: ./cmd/ejson/
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.VERSION={{.Version}} -extldflags "-static"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - freebsd
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64

--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,17 @@ build/man/%.gz: man/%.ronn
 	mkdir -p "$(@D)"
 	set -euo pipefail ; $(BUNDLE_EXEC) ronn -r --pipe "$<" | gzip > "$@" || (rm -f "$<" ; false)
 
-build/bin/linux-amd64: $(GOFILES) cmd/$(NAME)/version.go
+build/bin/linux-amd64: $(GOFILES)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-s -w -extldflags "-static"' -o "$@" "$(PACKAGE)/cmd/$(NAME)"
-build/bin/linux-arm64: $(GOFILES) cmd/$(NAME)/version.go
+build/bin/linux-arm64: $(GOFILES)
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags '-s -w -extldflags "-static"' -o "$@" "$(PACKAGE)/cmd/$(NAME)"
-build/bin/darwin-amd64: $(GOFILES) cmd/$(NAME)/version.go
+build/bin/darwin-amd64: $(GOFILES)
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags '-s -w -extldflags "-static"' -o "$@" "$(PACKAGE)/cmd/$(NAME)"
-build/bin/darwin-arm64: $(GOFILES) cmd/$(NAME)/version.go
+build/bin/darwin-arm64: $(GOFILES)
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags '-s -w -extldflags "-static"' -o "$@" "$(PACKAGE)/cmd/$(NAME)"
-build/bin/freebsd-amd64: $(GOFILES) cmd/$(NAME)/version.go
+build/bin/freebsd-amd64: $(GOFILES)
 	CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 go build -trimpath -ldflags '-s -w -extldflags "-static"' -o "$@" "$(PACKAGE)/cmd/$(NAME)"
-build/bin/windows-amd64.exe: $(GOFILES) cmd/$(NAME)/version.go
+build/bin/windows-amd64.exe: $(GOFILES)
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags '-s -w -extldflags "-static"' -o "$@" "$(PACKAGE)/cmd/$(NAME)"
 
 $(GEM): rubygem/$(NAME)-$(VERSION).gem
@@ -91,9 +91,6 @@ rubygem/build/linux-arm64/ejson: build/bin/linux-arm64
 rubygem/build/windows-amd64/ejson.exe: build/bin/windows-amd64.exe
 	mkdir -p $(@D)
 	cp -a "$<" "$@"
-
-cmd/$(NAME)/version.go: VERSION
-	printf '%b' 'package main\n\nconst VERSION string = "$(VERSION)"\n' > $@
 
 rubygem/lib/$(NAME)/version.rb: VERSION
 	mkdir -p $(@D)

--- a/cmd/ejson/actions.go
+++ b/cmd/ejson/actions.go
@@ -43,7 +43,7 @@ func decryptAction(args []string, keydir, userSuppliedPrivateKey, outFile string
 	return err
 }
 
-func keygenAction(args []string, keydir string, wFlag bool) error {
+func keygenAction(_ []string, keydir string, wFlag bool) error {
 	pub, priv, err := ejson.GenerateKeypair()
 	if err != nil {
 		return err

--- a/cmd/ejson/version.go
+++ b/cmd/ejson/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION string = "1.5.0"
+var VERSION string = "1.5.0"


### PR DESCRIPTION
Replace the logic in `Makefile` that replaces `cmd/ejson/version.go` with the current tag.

It's more common to inject these variables during linking, instead of generating source code.


Verify like:
```
$ cat cmd/ejson/version.go
package main

var VERSION string = "1.5.0"

$ goreleaser build --snapshot --rm-dist

$ dist/ejson_darwin_arm64/ejson --version
ejson version 1.5.1-SNAPSHOT-1ecf7d7
```

