### PR TITLE
release: sign .deb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,7 @@ jobs:
         uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
         with:
           subject-path: "dist/*.tar.gz"
+      - name: "Sign .deb"
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: "dist/*.deb"


### PR DESCRIPTION
In #154 we started uploading `.deb` artifacts.

I forgot we only sign `*.tar.gz`, so the deb's lack provenance. I can not abide.