### PR TITLE
upgrade goreleaser in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser
-          version: v1.25.1
+          version: v2.4.4
           args: release --clean --release-notes=tmp/release_changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Per https://github.com/Shopify/ejson/actions/runs/11705647618/job/32600858136

```
  ⨯ release failed after 0s                  error=only configurations files on version: 1 are supported, yours is version: 2, please update your configuration
```

# Related
- Cause https://github.com/Shopify/ejson/pull/157 , which upgraded to the `version: 2` format.