### PR TITLE
Fixed a typo in Makefile where ARM64_DEB wasn't defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PACKAGE=github.com/Shopify/ejson
 VERSION=$(shell cat VERSION)
 GEM=pkg/$(NAME)-$(VERSION).gem
 AMD64_DEB=dist/ejson_$(VERSION)_linux_amd64.deb
-AMD64_DEB=dist/ejson_$(VERSION)_linux_arm64.deb
+ARM64_DEB=dist/ejson_$(VERSION)_linux_arm64.deb
 
 GOFILES=$(shell find . -type f -name '*.go')
 


### PR DESCRIPTION
Looks like a typo in the `Makefile`. 

Though after making this change I realise it wasn't actually breaking anything.  The `$(ARM64_DEB)` rule target is redundant because all roads lead to `goreleaser release`, which handles the packaging for all systems and architectures.